### PR TITLE
feat: :sparkles: add settings configuration class

### DIFF
--- a/app/Application/Config/Settings.php
+++ b/app/Application/Config/Settings.php
@@ -42,4 +42,20 @@ final readonly class Settings
 
         return $this->data[$key] ?? null;
     }
+
+    /**
+     * Check for the existence of a top-level key in the settings array.
+     *
+     * This method determines whether the specified $key exists in the settings.
+     * Keys set to null are considered present since array_key_exists is used
+     * for the check.
+     *
+     * @param string $key Top-level key to check for existence
+     *
+     * @return bool True if the key exists in the settings array, otherwise false
+     */
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->data);
+    }
 }

--- a/app/Application/Config/Settings.php
+++ b/app/Application/Config/Settings.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Config;
+
+/**
+ * Simple configuration container for application settings.
+ *
+ * This immutable value object holds configuration data and provides a
+ * convenient accessor to retrieve either the whole configuration array
+ * or individual values by key.
+ */
+final readonly class Settings
+{
+    /**
+     * Construct a new Settings instance.
+     *
+     * @param array<string,mixed> $data The settings array to be exposed by this instance
+     */
+    public function __construct(
+        protected array $data,
+    ) {
+    }
+
+    /**
+     * Retrieve settings data.
+     *
+     * This method returns the full settings array when $key is null. When
+     * $key is provided, it returns the corresponding value or null if the
+     * key does not exist.
+     *
+     * @param string|null $key Optional top-level key to retrieve
+     *
+     * @return mixed Returns the full settings array when $key is null, otherwise the value or null
+     */
+    public function get(?string $key = null): mixed
+    {
+        if (null === $key) {
+            return $this->data;
+        }
+
+        return $this->data[$key] ?? null;
+    }
+}

--- a/app/Application/Config/Settings.php
+++ b/app/Application/Config/Settings.php
@@ -19,8 +19,20 @@ final readonly class Settings
      * @param array<string,mixed> $data The settings array to be exposed by this instance
      */
     public function __construct(
-        protected array $data,
+        private array $data,
     ) {
+    }
+
+    /**
+     * Retrieve all configuration settings.
+     *
+     * This method returns the entire settings array.
+     *
+     * @return array<string,mixed> The full configuration data
+     */
+    public function all(): array
+    {
+        return $this->data;
     }
 
     /**

--- a/app/Application/Config/Settings.php
+++ b/app/Application/Config/Settings.php
@@ -24,23 +24,30 @@ final readonly class Settings
     }
 
     /**
-     * Retrieve settings data.
+     * Retrieve a configuration value by key.
      *
-     * This method returns the full settings array when $key is null. When
-     * $key is provided, it returns the corresponding value or null if the
-     * key does not exist.
+     * This method returns the value for the provided $key. If the key does
+     * not exist in the settings, it will return $default if provided;
+     * otherwise, it throws an InvalidArgumentException.
      *
-     * @param string|null $key Optional top-level key to retrieve
+     * @param string     $key     The top-level key to retrieve
+     * @param mixed|null $default Optional default value to return if key is missing
      *
-     * @return mixed Returns the full settings array when $key is null, otherwise the value or null
+     * @return mixed The value associated with the key, or $default if provided
+     *
+     * @throws \InvalidArgumentException If the key does not exist and no default is provided
      */
-    public function get(?string $key = null): mixed
+    public function get(string $key, mixed $default = null): mixed
     {
-        if (null === $key) {
-            return $this->data;
+        if (array_key_exists($key, $this->data)) {
+            return $this->data[$key];
         }
 
-        return $this->data[$key] ?? null;
+        if (func_num_args() === 2) {
+            return $default;
+        }
+
+        throw new \InvalidArgumentException("Configuration key '{$key}' not found.");
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Application\Config\Settings;
 use Monolog\Logger;
 use Slim\Factory\AppFactory;
 
@@ -26,12 +27,12 @@ $app->addBodyParsingMiddleware();
 
 // Configure error handling middleware with application settings and logging
 // Retrieves display and logging preferences from settings to handle exceptions appropriately
-$settings = $container->get('settings');
+$settings = $container->get(Settings::class);
 $logger = $container->get(Logger::class);
 $app->addErrorMiddleware(
-    $settings['app']['display_error_details'],
-    $settings['app']['log_errors'],
-    $settings['app']['log_error_details'],
+    $settings->get('display_error_details'),
+    $settings->get('log_errors'),
+    $settings->get('log_error_details'),
     $logger
 );
 

--- a/bootstrap/container.php
+++ b/bootstrap/container.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Application\Config\Settings;
 use DI\Container;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\RotatingFileHandler;
@@ -16,22 +17,24 @@ use Monolog\Logger;
  */
 return function(Container $container) {
     $container->set(Logger::class, function($container) {
-        $settings = $container->get('settings')['logger'];
+        $settings = $container->get(Settings::class);
 
-        $logger = new Logger($settings['name']);
+        $loggerSettings = $settings->get('logger');
+
+        $logger = new Logger($loggerSettings['name']);
 
         $handler = new RotatingFileHandler(
             root_path('storage/logs/app.log'),
-            $settings['handler']['max_files'],
-            $settings['handler']['level']
+            $loggerSettings['handler']['max_files'],
+            $loggerSettings['handler']['level']
         );
 
         $formatter = new LineFormatter(
-            $settings['formatter']['format'],
-            $settings['formatter']['date_format'],
-            $settings['formatter']['allow_inline_line_breaks'],
-            $settings['formatter']['ignore_empty_context_and_extra'],
-            $settings['formatter']['include_stack_traces']
+            $loggerSettings['formatter']['format'],
+            $loggerSettings['formatter']['date_format'],
+            $loggerSettings['formatter']['allow_inline_line_breaks'],
+            $loggerSettings['formatter']['ignore_empty_context_and_extra'],
+            $loggerSettings['formatter']['include_stack_traces']
         );
 
         $handler->setFormatter($formatter);

--- a/bootstrap/settings.php
+++ b/bootstrap/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Application\Config\Settings;
 use DI\Container;
 use Monolog\Logger;
 
@@ -13,13 +14,11 @@ use Monolog\Logger;
  * @return void
  */
 return function(Container $container) {
-    $container->set('settings', function() {
-        return [
-            'app' => [
-                'display_error_details' => (bool)get_env('APP_DISPLAY_ERROR_DETAILS', false),
-                'log_errors' => (bool)get_env('APP_LOG_ERRORS', true),
-                'log_error_details' => (bool)get_env('APP_LOG_ERROR_DETAILS', true),
-            ],
+    $container->set(Settings::class, function() {
+        return new Settings([
+            'display_error_details' => (bool)get_env('APP_DISPLAY_ERROR_DETAILS', false),
+            'log_errors' => (bool)get_env('APP_LOG_ERRORS', true),
+            'log_error_details' => (bool)get_env('APP_LOG_ERROR_DETAILS', true),
             'logger' => [
                 'name' => get_env('LOGGER_NAME', 'app'),
                 'handler' => [
@@ -34,6 +33,6 @@ return function(Container $container) {
                     'include_stack_traces' => (bool)get_env('LOGGER_FORMATTER_INCLUDE_STACK_TRACES', false)
                 ],
             ],
-        ];
+        ]);
     });
 };

--- a/tests/Unit/Application/Config/SettingsTest.php
+++ b/tests/Unit/Application/Config/SettingsTest.php
@@ -66,4 +66,24 @@ final class SettingsTest extends TestCase
 
         $this->assertSame(['a' => 1], $settings->get('nested'));
     }
+
+    /**
+     * Test that has($key) accurately reports the existence of keys.
+     *
+     * Verifies that the Settings instance correctly identifies present and
+     * missing keys, treating keys set to null as existing because the check
+     * uses array_key_exists().
+     *
+     * @return void
+     */
+    public function testHasDetectsExistingAndMissingKeys(): void
+    {
+        $data = ['present' => null, 'other' => 123];
+
+        $settings = new Settings($data);
+
+        $this->assertTrue($settings->has('present'));
+        $this->assertTrue($settings->has('other'));
+        $this->assertFalse($settings->has('missing'));
+    }
 }

--- a/tests/Unit/Application/Config/SettingsTest.php
+++ b/tests/Unit/Application/Config/SettingsTest.php
@@ -32,6 +32,7 @@ final class SettingsTest extends TestCase
 
         $this->assertSame($data, $settings->all());
     }
+
     /**
      * Test that get() returns the value for an existing key.
      *

--- a/tests/Unit/Application/Config/SettingsTest.php
+++ b/tests/Unit/Application/Config/SettingsTest.php
@@ -17,6 +17,22 @@ use PHPUnit\Framework\TestCase;
 final class SettingsTest extends TestCase
 {
     /**
+     * Test that all() returns all settings data.
+     *
+     * Verifies that the all() method returns the complete set of configuration data
+     * as an associative array.
+     *
+     * @return void
+     */
+    public function testAllReturnsAllSettings(): void
+    {
+        $data = ['one' => 1, 'two' => ['a' => 'b']];
+
+        $settings = new Settings($data);
+
+        $this->assertSame($data, $settings->all());
+    }
+    /**
      * Test that get() returns the value for an existing key.
      *
      * Verifies that when a valid key is provided, the expected value is returned.

--- a/tests/Unit/Application/Config/SettingsTest.php
+++ b/tests/Unit/Application/Config/SettingsTest.php
@@ -17,52 +17,60 @@ use PHPUnit\Framework\TestCase;
 final class SettingsTest extends TestCase
 {
     /**
-     * Test that get() with no key returns the full settings array.
+     * Test that get() returns the value for an existing key.
      *
-     * Verifies that when no key is provided the Settings instance returns
-     * the entire configuration array that was passed to the constructor.
-     *
-     * @return void
-     */
-    public function testGetAllReturnsSettingsArray(): void
-    {
-        $data = ['foo' => 'bar', 'nested' => ['a' => 1]];
-
-        $settings = new Settings($data);
-
-        $this->assertSame($data, $settings->get());
-    }
-
-    /**
-     * Test that get($key) returns the value for an existing key.
-     *
-     * Verifies that when a valid key is provided the expected scalar value
-     * is returned from the Settings instance.
+     * Verifies that when a valid key is provided, the expected value is returned.
      *
      * @return void
      */
     public function testGetExistingKeyReturnsValue(): void
     {
-        $data = ['foo' => 'bar'];
-
-        $settings = new Settings($data);
+        $settings = new Settings(['foo' => 'bar']);
 
         $this->assertSame('bar', $settings->get('foo'));
     }
 
     /**
-     * Test that get($key) returns nested arrays as expected.
+     * Test that get() returns the default value if key is missing.
      *
-     * Verifies that nested configuration values (arrays) are returned intact
-     * when requested by their top-level key.
+     * Confirms that when a key does not exist, the provided default is returned instead of throwing.
+     *
+     * @return void
+     */
+    public function testGetMissingKeyReturnsDefault(): void
+    {
+        $settings = new Settings(['foo' => 'bar']);
+
+        $this->assertSame('default', $settings->get('baz', 'default'));
+        $this->assertNull($settings->get('baz', null));
+    }
+
+    /**
+     * Test that get() throws an exception if key is missing and no default provided.
+     *
+     * Ensures that missing keys without a default trigger an InvalidArgumentException.
+     *
+     * @return void
+     */
+    public function testGetMissingKeyThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Configuration key 'baz' not found.");
+
+        $settings = new Settings(['foo' => 'bar']);
+        $settings->get('baz');
+    }
+
+    /**
+     * Test that get() returns nested arrays correctly.
+     *
+     * Ensures that nested configuration values are returned intact when requested by their top-level key.
      *
      * @return void
      */
     public function testGetNestedKeyReturnsArray(): void
     {
-        $data = ['nested' => ['a' => 1]];
-
-        $settings = new Settings($data);
+        $settings = new Settings(['nested' => ['a' => 1]]);
 
         $this->assertSame(['a' => 1], $settings->get('nested'));
     }

--- a/tests/Unit/Application/Config/SettingsTest.php
+++ b/tests/Unit/Application/Config/SettingsTest.php
@@ -25,7 +25,9 @@ final class SettingsTest extends TestCase
      */
     public function testGetExistingKeyReturnsValue(): void
     {
-        $settings = new Settings(['foo' => 'bar']);
+        $data = ['foo' => 'bar'];
+
+        $settings = new Settings($data);
 
         $this->assertSame('bar', $settings->get('foo'));
     }
@@ -39,7 +41,9 @@ final class SettingsTest extends TestCase
      */
     public function testGetMissingKeyReturnsDefault(): void
     {
-        $settings = new Settings(['foo' => 'bar']);
+        $data = ['foo' => 'bar'];
+
+        $settings = new Settings($data);
 
         $this->assertSame('default', $settings->get('baz', 'default'));
         $this->assertNull($settings->get('baz', null));
@@ -57,7 +61,9 @@ final class SettingsTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Configuration key 'baz' not found.");
 
-        $settings = new Settings(['foo' => 'bar']);
+        $data = ['foo' => 'bar'];
+
+        $settings = new Settings($data);
         $settings->get('baz');
     }
 
@@ -70,7 +76,9 @@ final class SettingsTest extends TestCase
      */
     public function testGetNestedKeyReturnsArray(): void
     {
-        $settings = new Settings(['nested' => ['a' => 1]]);
+        $data = ['nested' => ['a' => 1]];
+
+        $settings = new Settings($data);
 
         $this->assertSame(['a' => 1], $settings->get('nested'));
     }

--- a/tests/Unit/Application/Config/SettingsTest.php
+++ b/tests/Unit/Application/Config/SettingsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Config;
+
+use App\Application\Config\Settings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test cases for the Settings application configuration holder.
+ *
+ * This test class verifies that the Settings object correctly exposes
+ * configuration data, both as a whole and by individual keys, including
+ * nested arrays.
+ */
+final class SettingsTest extends TestCase
+{
+    /**
+     * Test that get() with no key returns the full settings array.
+     *
+     * Verifies that when no key is provided the Settings instance returns
+     * the entire configuration array that was passed to the constructor.
+     *
+     * @return void
+     */
+    public function testGetAllReturnsSettingsArray(): void
+    {
+        $data = ['foo' => 'bar', 'nested' => ['a' => 1]];
+
+        $settings = new Settings($data);
+
+        $this->assertSame($data, $settings->get());
+    }
+
+    /**
+     * Test that get($key) returns the value for an existing key.
+     *
+     * Verifies that when a valid key is provided the expected scalar value
+     * is returned from the Settings instance.
+     *
+     * @return void
+     */
+    public function testGetExistingKeyReturnsValue(): void
+    {
+        $data = ['foo' => 'bar'];
+
+        $settings = new Settings($data);
+
+        $this->assertSame('bar', $settings->get('foo'));
+    }
+
+    /**
+     * Test that get($key) returns nested arrays as expected.
+     *
+     * Verifies that nested configuration values (arrays) are returned intact
+     * when requested by their top-level key.
+     *
+     * @return void
+     */
+    public function testGetNestedKeyReturnsArray(): void
+    {
+        $data = ['nested' => ['a' => 1]];
+
+        $settings = new Settings($data);
+
+        $this->assertSame(['a' => 1], $settings->get('nested'));
+    }
+}


### PR DESCRIPTION
This pull request refactors how application configuration settings are managed and accessed throughout the codebase. It introduces a new immutable `Settings` value object, updates dependency injection to use this class, and modifies all usages to leverage its accessor methods. Additionally, unit tests are added to verify its behavior. The main themes are improved configuration encapsulation and code consistency.

**Configuration Management Refactor**

* Added new immutable `Settings` value object in `app/Application/Config/Settings.php` to encapsulate application configuration and provide convenient accessors.
* Updated dependency injection in `bootstrap/settings.php` to register `Settings` as a service instead of a raw array, and refactored configuration setup to instantiate this object. [[1]](diffhunk://#diff-a98e3b1ff053371fd3498caeae280d92c4722454e58f879007bf10475bda09abR3) [[2]](diffhunk://#diff-a98e3b1ff053371fd3498caeae280d92c4722454e58f879007bf10475bda09abL16-L22) [[3]](diffhunk://#diff-a98e3b1ff053371fd3498caeae280d92c4722454e58f879007bf10475bda09abL37-R36)

**Codebase Consistency**

* Refactored all usages of settings in `bootstrap/app.php` and `bootstrap/container.php` to retrieve configuration via the `Settings` object and its `get()` method, replacing direct array access. [[1]](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R3) [[2]](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518L29-R35) [[3]](diffhunk://#diff-6bf570b9f96e9ddd643cbf660ed217be658b4488d1b471e48e1848a879586689R3) [[4]](diffhunk://#diff-6bf570b9f96e9ddd643cbf660ed217be658b4488d1b471e48e1848a879586689L19-R37)

**Testing**

* Added unit tests for the `Settings` class in `tests/Unit/Application/Config/SettingsTest.php` to verify correct retrieval of configuration data and support for nested arrays.…app settings management