### PR TITLE
refactor: :hammer: add PHPUnit configuration and update testing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ Keeping dependencies up-to-date is crucial for maintaining the security and perf
 
 Please write tests for any new features or modifications to the project.
 
-Run the full test suite with `composer test`.
+- Run the full test suite with `composer test`.
+- Use `composer test:unit` for fast, isolated unit tests during development.
+- Use `composer test:integration` to verify end-to-end behaviour across layers.
 
 Tests live under `tests/` and are organised into two suites:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,16 +50,20 @@ Keeping dependencies up-to-date is crucial for maintaining the security and perf
 
 Please write tests for any new features or modifications to the project.
 
-- Run the full test suite with `composer test`.
-- Use `composer test:unit` for fast, isolated unit tests during development.
-- Use `composer test:integration` to verify end-to-end behaviour across layers.
-
 Tests live under `tests/` and are organised into two suites:
 
 - `tests/Unit/` — isolated unit tests for individual classes and methods
 - `tests/Integration/` — tests that exercise multiple layers working together
 
-Guidelines:
+The test suite is configured via `phpunit.xml`, which defines test suites, source directories, and environment variables. By default, the `APP_ENV` variable is set to `testing` when running tests, and this can be extended to suit your needs.
+
+You can run tests using the provided Composer scripts:
+
+- Run the full test suite with `composer test`
+- Use `composer test:unit` for fast, isolated unit tests during development
+- Use `composer test:integration` to verify end-to-end behaviour across layers
+
+For consistency and maintainability:
 
 - Keep tests focused and readable
 - Prefer small, isolated test cases

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,9 @@
     ],
     "scripts": {
         "cs": "php-cs-fixer fix",
-        "post-root-package-install": [
-            "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ]
+        "test": "phpunit",
+        "test:unit": "phpunit --testsuite Unit",
+        "test:integration": "phpunit --testsuite Integration"
     },
     "config": {
         "optimize-autoloader": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true">
+	<testsuites>
+		<testsuite name="Unit">
+			<directory>tests/Unit</directory>
+		</testsuite>
+		<testsuite name="Integration">
+			<directory>tests/Integration</directory>
+		</testsuite>
+	</testsuites>
+	<source>
+		<include>
+			<directory>app</directory>
+		</include>
+	</source>
+	<php>
+		<env name="APP_ENV" value="testing"/>
+	</php>
+</phpunit>

--- a/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
@@ -46,7 +46,7 @@ class CreateUserDTOTest extends TestCase
      *
      * @return array<string, array<mixed>> Named sets of invalid payloads.
      */
-    public function invalidPayloadProvider(): array
+    public static function invalidPayloadProvider(): array
     {
         return [
             'missing first name' => [[


### PR DESCRIPTION
This pull request improves the project's testing infrastructure by introducing a dedicated PHPUnit configuration, updating test-related documentation, and enhancing Composer scripts for running tests. The changes make it easier to run and manage both unit and integration tests, and clarify testing practices for contributors.

**Testing infrastructure improvements:**

* Added a new `phpunit.xml` configuration file to define test suites, source directories, and default environment variables for running tests. This ensures consistent and reliable test execution across environments.
* Updated `composer.json` to add Composer scripts for running the full test suite (`composer test`), unit tests (`composer test:unit`), and integration tests (`composer test:integration`), streamlining the testing workflow.

**Documentation updates:**

* Enhanced the testing section in `CONTRIBUTING.md` to explain the new PHPUnit configuration, describe the available Composer scripts for running tests, and provide clearer guidance on organizing and writing tests.