### PR TITLE
feat: :sparkles: add CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ APP_ENV=dev
 APP_KEY=supersecretkeyyoushouldnotcommittogithub
 APP_URL=http://localhost:8888
 
+# CORS
+# ==============================================================================
+# Comma-separated list of allowed origins.
+# Use * to allow any origin (credentials are disabled with wildcard).
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
 # LOGGER
 # ==============================================================================
 LOGGER_NAME="logger"

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -48,6 +48,31 @@ if (!function_exists('get_env')) {
     }
 }
 
+if (!function_exists('get_env_array')) {
+    /**
+     * Retrieves an environment variable as an array, split by a delimiter.
+     *
+     * Empty values return an empty array.
+     *
+     * @param  string             $key       Environment variable name.
+     * @param  string             $delimiter Delimiter used to split the string.
+     * @return array<int, string>
+     */
+    function get_env_array(string $key, string $delimiter = ','): array
+    {
+        $value = get_env($key, '');
+
+        if (!is_string($value) || $value === '') {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map('trim', explode($delimiter, $value)),
+            static fn (string $item): bool => $item !== ''
+        ));
+    }
+}
+
 if (!function_exists('require_from_root')) {
     /**
      * Requires a file relative to the project root.

--- a/bootstrap/settings.php
+++ b/bootstrap/settings.php
@@ -20,6 +20,9 @@ return function(ContainerBuilder $containerBuilder): void {
                     'key' => get_env('APP_KEY'),
                     'url' => get_env('APP_URL', 'https://localhost:8888'),
                 ],
+                'cors' => [
+                    'allowedOrigins' => get_env_array('CORS_ALLOWED_ORIGINS'),
+                ],
                 'logger' => [
                     'name' => get_env('LOGGER_NAME', 'app'),
                     'handler' => [

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.3",
         "andrewdyer/actions": "^0.1",
         "andrewdyer/settings": "dev-main",
-        "andrewdyer/slim-cors-response-emitter": "dev-main",
+        "andrewdyer/slim-cors-response-emitter": "^0.1",
         "monolog/monolog": "^3.10",
         "php-di/php-di": "^7.1",
         "slim/psr7": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e685764b0d567826724712f46d4a499e",
+    "content-hash": "bcc3ee4f3c70dd9e2e6e69eee8b7c7fd",
     "packages": [
         {
             "name": "andrewdyer/actions",
-            "version": "0.1.0",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/andrewdyer/actions.git",
-                "reference": "e692c568438a40be0b71896c8c0574b9bfe35737"
+                "reference": "33b4c46962f0c0f622c4ca69e4e1c7c5a074538b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/andrewdyer/actions/zipball/e692c568438a40be0b71896c8c0574b9bfe35737",
-                "reference": "e692c568438a40be0b71896c8c0574b9bfe35737",
+                "url": "https://api.github.com/repos/andrewdyer/actions/zipball/33b4c46962f0c0f622c4ca69e4e1c7c5a074538b",
+                "reference": "33b4c46962f0c0f622c4ca69e4e1c7c5a074538b",
                 "shasum": ""
             },
             "require": {
@@ -44,12 +44,20 @@
             "license": [
                 "MIT"
             ],
-            "description": "Framework-agnostic action utilities for building structured and predictable JSON API endpoints",
+            "description": "A framework-agnostic PHP library for building structured and predictable JSON API endpoints with standardised request and response handling",
+            "keywords": [
+                "JSON-API",
+                "actions",
+                "api",
+                "framework-agnostic",
+                "php",
+                "psr-7"
+            ],
             "support": {
                 "issues": "https://github.com/andrewdyer/actions/issues",
-                "source": "https://github.com/andrewdyer/actions/tree/0.1.0"
+                "source": "https://github.com/andrewdyer/actions/tree/0.1.2"
             },
-            "time": "2026-03-31T09:53:12+00:00"
+            "time": "2026-03-31T16:06:07+00:00"
         },
         {
             "name": "andrewdyer/settings",
@@ -57,12 +65,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/andrewdyer/settings.git",
-                "reference": "eee8f5f2c5937b632d0d3a1fd93faad567415f43"
+                "reference": "282647bf85f132a7c139692295fc3095af00bcab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/andrewdyer/settings/zipball/eee8f5f2c5937b632d0d3a1fd93faad567415f43",
-                "reference": "eee8f5f2c5937b632d0d3a1fd93faad567415f43",
+                "url": "https://api.github.com/repos/andrewdyer/settings/zipball/282647bf85f132a7c139692295fc3095af00bcab",
+                "reference": "282647bf85f132a7c139692295fc3095af00bcab",
                 "shasum": ""
             },
             "require": {
@@ -83,25 +91,32 @@
             "license": [
                 "MIT"
             ],
-            "description": "A lightweight, framework-agnostic settings container for managing configuration in PHP applications",
+            "description": "A framework-agnostic PHP settings library for managing application configuration in a consistent and structured way",
+            "keywords": [
+                "Settings",
+                "config",
+                "configuration",
+                "framework-agnostic",
+                "php"
+            ],
             "support": {
                 "issues": "https://github.com/andrewdyer/settings/issues",
                 "source": "https://github.com/andrewdyer/settings/tree/main"
             },
-            "time": "2026-03-26T22:43:03+00:00"
+            "time": "2026-03-31T16:02:17+00:00"
         },
         {
             "name": "andrewdyer/slim-cors-response-emitter",
-            "version": "dev-main",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/andrewdyer/slim-cors-response-emitter.git",
-                "reference": "f560d8bd1cbf5b3c59fa987a2e0ed0740b05bc36"
+                "reference": "e6fba292823b6b78bfb4b4d87291b8d390aea2d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/andrewdyer/slim-cors-response-emitter/zipball/f560d8bd1cbf5b3c59fa987a2e0ed0740b05bc36",
-                "reference": "f560d8bd1cbf5b3c59fa987a2e0ed0740b05bc36",
+                "url": "https://api.github.com/repos/andrewdyer/slim-cors-response-emitter/zipball/e6fba292823b6b78bfb4b4d87291b8d390aea2d4",
+                "reference": "e6fba292823b6b78bfb4b4d87291b8d390aea2d4",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +128,6 @@
                 "friendsofphp/php-cs-fixer": "^3.75",
                 "phpunit/phpunit": "^10.5"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -124,12 +138,20 @@
             "license": [
                 "MIT"
             ],
-            "description": "A CORS-aware response emitter for Slim applications.",
+            "description": "A CORS-aware response emitter for Slim PHP applications, designed to ensure consistent and secure HTTP responses",
+            "keywords": [
+                "cors",
+                "http",
+                "middleware",
+                "php",
+                "psr-7",
+                "slim"
+            ],
             "support": {
                 "issues": "https://github.com/andrewdyer/slim-cors-response-emitter/issues",
-                "source": "https://github.com/andrewdyer/slim-cors-response-emitter/tree/main"
+                "source": "https://github.com/andrewdyer/slim-cors-response-emitter/tree/0.1.0"
             },
-            "time": "2026-03-22T23:25:43+00:00"
+            "time": "2026-03-31T21:18:00+00:00"
         },
         {
             "name": "fig/http-message-util",
@@ -5588,8 +5610,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "andrewdyer/settings": 20,
-        "andrewdyer/slim-cors-response-emitter": 20
+        "andrewdyer/settings": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use AndrewDyer\Settings\Contracts\SettingsInterface;
 use AndrewDyer\Slim\CorsResponseEmitter;
 use Slim\Factory\ServerRequestCreatorFactory;
 
@@ -14,6 +15,10 @@ $app = $appFactory();
 $serverRequestCreator = ServerRequestCreatorFactory::create();
 $request = $serverRequestCreator->createServerRequestFromGlobals();
 
+$container = $app->getContainer();
+
+$settings = $container->get(SettingsInterface::class);
+
 $response = $app->handle($request);
-$corsResponseEmitter = new CorsResponseEmitter();
+$corsResponseEmitter = new CorsResponseEmitter($settings->get('cors.allowedOrigins'));
 $corsResponseEmitter->emit($response);

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for helper functions.
+ */
+final class HelpersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_ENV = [];
+    }
+
+    /**
+     * Asserts that the default value is returned when the key is missing.
+     */
+    public function testGetEnvReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame('default', get_env('MISSING_KEY', 'default'));
+    }
+
+    /**
+     * Asserts that string values are returned without modification.
+     */
+    public function testGetEnvReturnsStringValue(): void
+    {
+        $_ENV['SOME_KEY'] = 'some-value';
+
+        $this->assertSame('some-value', get_env('SOME_KEY'));
+    }
+
+    /**
+     * Asserts that "true" is cast to a boolean true.
+     */
+    public function testGetEnvCastsTrue(): void
+    {
+        $_ENV['FLAG_KEY'] = 'true';
+
+        $this->assertTrue(get_env('FLAG_KEY'));
+    }
+
+    /**
+     * Asserts that "false" is cast to a boolean false.
+     */
+    public function testGetEnvCastsFalse(): void
+    {
+        $_ENV['FLAG_KEY'] = 'false';
+
+        $this->assertFalse(get_env('FLAG_KEY'));
+    }
+
+    /**
+     * Asserts that an empty array is returned when the key is missing.
+     */
+    public function testGetEnvArrayReturnsEmptyWhenMissing(): void
+    {
+        $this->assertSame([], get_env_array('LIST_KEY'));
+    }
+
+    /**
+     * Asserts that comma-separated values are split into an array.
+     */
+    public function testGetEnvArraySplitsValues(): void
+    {
+        $_ENV['LIST_KEY'] = 'a,b,c';
+
+        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY'));
+    }
+
+    /**
+     * Asserts that values are trimmed and empty entries are removed.
+     */
+    public function testGetEnvArrayTrimsAndFilters(): void
+    {
+        $_ENV['LIST_KEY'] = ' a, ,b , , c ';
+
+        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY'));
+    }
+}

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -11,11 +11,32 @@ use PHPUnit\Framework\TestCase;
  */
 final class HelpersTest extends TestCase
 {
+    /**
+     * Backup of the original $_ENV array.
+     * @var array
+     */
+    private array $originalEnv;
+
+    /**
+     * {@inheritdoc}
+     */
     protected function setUp(): void
     {
         parent::setUp();
 
-        $_ENV = [];
+        $this->originalEnv = $_ENV;
+
+        unset($_ENV['SOME_KEY'], $_ENV['FLAG_KEY'], $_ENV['LIST_KEY'], $_ENV['MISSING_KEY']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        $_ENV = $this->originalEnv;
+
+        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
This pull request adds support for configuring CORS allowed origins via environment variables, introduces a new helper function for parsing environment variables as arrays, updates dependencies, and improves test coverage for helper functions. The main changes are grouped as follows:

**CORS Configuration Enhancements:**

* Added a `CORS_ALLOWED_ORIGINS` variable to `.env.example` to allow specifying allowed origins for CORS as a comma-separated list.
* Updated the application settings to include a `cors` section, loading allowed origins using the new helper.
* Modified the application bootstrap (`public/index.php`) to pass allowed origins from settings to the `CorsResponseEmitter`. [[1]](diffhunk://#diff-ab1615a3a159df0750aa7b76472124966ab3076c26abcd050f6b9120fbda6c61R5) [[2]](diffhunk://#diff-ab1615a3a159df0750aa7b76472124966ab3076c26abcd050f6b9120fbda6c61R18-R23)

**Helper Function Improvements:**

* Introduced `get_env_array` in `app/helpers.php` to retrieve and parse environment variables as arrays, with trimming and filtering of empty values.

**Dependency Updates:**

* Updated `composer.json` to require a stable version of `andrewdyer/slim-cors-response-emitter` instead of a dev version.

**Testing Improvements:**

* Added `tests/Unit/HelpersTest.php` to provide unit tests for both `get_env` and the new `get_env_array` helper functions, covering various edge cases.