### PR TITLE
chore: :wrench: update PHP development server start command to use composer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ To get started with contributing, set up the project by following these steps:
 2. Ensure you have PHP 8.3 or higher installed.
 3. Copy the example environment file with `cp .env.example .env` and update the values for your local setup.
 4. Install all project dependencies with `composer install`.
-5. Start the built-in PHP development server with `php -S 127.0.0.1:8888 -t public public/index.php`.
+5. Start the built-in PHP development server with `composer start`.
 
 ## Environment
 

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     ],
     "scripts": {
         "cs": "php-cs-fixer fix",
+        "start": "php -S 127.0.0.1:8888 -t public public/index.php",
         "test": "phpunit",
         "test:unit": "phpunit --testsuite Unit",
         "test:integration": "phpunit --testsuite Integration"


### PR DESCRIPTION
This pull request updates the development workflow documentation and project scripts to streamline starting the local development server. The main change is the introduction of a `composer start` script, which simplifies how developers run the PHP built-in server.

**Developer workflow improvements:**

* Added a `start` script to `composer.json` that runs the PHP built-in server (`php -S 127.0.0.1:8888 -t public public/index.php`), making it easier to start the project with a single command.
* Updated the setup instructions in `CONTRIBUTING.md` to direct developers to use `composer start` instead of the raw PHP command when starting the development server.Change the command to start the PHP development server to use `composer start` for easier setup.