### PR TITLE
refactor: :hammer: add HTTP request examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ repo/
 ├── public/                      # Web server document root
 │   └── index.php                # HTTP entry point
 │
+├── resources/                   # Development & documentation assets
+│   └── http/                    # HTTP request/response examples
+│
 ├── storage/                     # File-based storage
 │   └── logs/                    # Monolog output
 │

--- a/app/Infrastructure/Persistence/User/InMemoryUserRepository.php
+++ b/app/Infrastructure/Persistence/User/InMemoryUserRepository.php
@@ -29,11 +29,11 @@ final class InMemoryUserRepository implements UserRepository
      */
     public function __construct()
     {
-        $this->create('Bill', 'Gates', 'billgates@example.com');
-        $this->create('Steve', 'Jobs', 'stevejobs@example.com');
-        $this->create('Mark', 'Zuckerberg', 'markzuckerberg@example.com');
-        $this->create('Evan', 'Spiegel', 'evanspiegel@example.com');
-        $this->create('Jack', 'Dorsey', 'jackdorsey@example.com');
+        $this->create('Oliver', 'Taylor', 'oliver.taylor@example.com');
+        $this->create('Charlotte', 'Anderson', 'charlotte.anderson@example.com');
+        $this->create('Henry', 'Thomas', 'henry.thomas@example.com');
+        $this->create('Amelia', 'Moore', 'amelia.moore@example.com');
+        $this->create('Lucas', 'Martin', 'lucas.martin@example.com');
     }
 
     /**

--- a/app/Infrastructure/Persistence/User/InMemoryUserRepository.php
+++ b/app/Infrastructure/Persistence/User/InMemoryUserRepository.php
@@ -29,7 +29,7 @@ final class InMemoryUserRepository implements UserRepository
      */
     public function __construct()
     {
-        $this->create('Oliver', 'Taylor', 'oliver.taylor@example.com');
+        $this->create('Oliver', 'French', 'oliver.french@example.com');
         $this->create('Charlotte', 'Anderson', 'charlotte.anderson@example.com');
         $this->create('Henry', 'Thomas', 'henry.thomas@example.com');
         $this->create('Amelia', 'Moore', 'amelia.moore@example.com');

--- a/resources/http/users.http
+++ b/resources/http/users.http
@@ -1,6 +1,5 @@
 @baseUrl = http://localhost:8888
 @userId = 1
-
 ###
 
 ### ==================================================
@@ -19,9 +18,9 @@ Content-Type: application/json
 Accept: application/json
 
 {
-    "first_name": "Elon",
-    "last_name": "Musk",
-    "email": "elonmusk@example.com"
+    "first_name": "Emily",
+    "last_name": "Johnson",
+    "email": "emily.johnson@example.com"
 }
 
 ###
@@ -42,9 +41,9 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "first_name": "Larry",
-  "last_name": "Page",
-  "email": "larrypage@example.com"
+  "first_name": "Michael",
+  "last_name": "Brown",
+  "email": "michael.brown@example.com"
 }
 
 ###

--- a/resources/http/users.http
+++ b/resources/http/users.http
@@ -1,0 +1,72 @@
+@baseUrl = http://localhost:8888
+@userId = 1
+
+###
+
+### ==================================================
+### USERS: LIST (INITIAL STATE)
+### ==================================================
+GET {{baseUrl}}/api/v1/users
+Accept: application/json
+
+###
+
+### ==================================================
+### USERS: CREATE
+### ==================================================
+POST {{baseUrl}}/api/v1/users
+Content-Type: application/json
+Accept: application/json
+
+{
+    "first_name": "Elon",
+    "last_name": "Musk",
+    "email": "elonmusk@example.com"
+}
+
+###
+
+### ==================================================
+### USERS: SHOW
+### ==================================================
+GET {{baseUrl}}/api/v1/users/{{userId}}
+Accept: application/json
+
+###
+
+### ==================================================
+### USERS: UPDATE
+### ==================================================
+PUT {{baseUrl}}/api/v1/users/{{userId}}
+Content-Type: application/json
+Accept: application/json
+
+{
+  "first_name": "Larry",
+  "last_name": "Page",
+  "email": "larrypage@example.com"
+}
+
+###
+
+### ==================================================
+### USERS: LIST (AFTER UPDATE)
+### ==================================================
+GET {{baseUrl}}/api/v1/users
+Accept: application/json
+
+###
+
+### ==================================================
+### USERS: DELETE
+### ==================================================
+DELETE {{baseUrl}}/api/v1/users/{{userId}}
+Accept: application/json
+
+###
+
+### ==================================================
+### USERS: LIST (FINAL STATE)
+### ==================================================
+GET {{baseUrl}}/api/v1/users
+Accept: application/json

--- a/resources/http/users.http
+++ b/resources/http/users.http
@@ -18,9 +18,9 @@ Content-Type: application/json
 Accept: application/json
 
 {
-    "first_name": "Emily",
-    "last_name": "Johnson",
-    "email": "emily.johnson@example.com"
+  "first_name": "Emily",
+  "last_name": "Johnson",
+  "email": "emily.johnson@example.com"
 }
 
 ###

--- a/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
@@ -43,8 +43,8 @@ class ListUsersActionTest extends AbstractIntegrationTestCase
         $this->assertArrayHasKey('email', $first);
 
         $this->assertSame(1, $first['id']);
-        $this->assertSame('Bill', $first['firstName']);
-        $this->assertSame('Gates', $first['lastName']);
-        $this->assertSame('billgates@example.com', $first['email']);
+        $this->assertSame('Oliver', $first['firstName']);
+        $this->assertSame('French', $first['lastName']);
+        $this->assertSame('oliver.french@example.com', $first['email']);
     }
 }

--- a/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
@@ -26,9 +26,9 @@ class ShowUserActionTest extends AbstractIntegrationTestCase
 
         $user = $body['data'];
         $this->assertSame(1, $user['id']);
-        $this->assertSame('Bill', $user['firstName']);
-        $this->assertSame('Gates', $user['lastName']);
-        $this->assertSame('billgates@example.com', $user['email']);
+        $this->assertSame('Oliver', $user['firstName']);
+        $this->assertSame('French', $user['lastName']);
+        $this->assertSame('oliver.french@example.com', $user['email']);
     }
 
     /**

--- a/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
@@ -17,9 +17,9 @@ class UpdateUserActionTest extends AbstractIntegrationTestCase
     public function testReturns200WithUpdatedUserWhenUserExists(): void
     {
         $response = $this->request('PUT', '/api/v1/users/1', [
-            'first_name' => 'William',
-            'last_name' => 'Gates III',
-            'email' => 'william.gates@example.com',
+            'first_name' => 'Ollie',
+            'last_name' => 'Frenchie',
+            'email' => 'ollie.frenchie@example.com',
         ]);
 
         $this->assertSame(200, $response->getStatusCode());
@@ -30,9 +30,9 @@ class UpdateUserActionTest extends AbstractIntegrationTestCase
 
         $user = $body['data'];
         $this->assertSame(1, $user['id']);
-        $this->assertSame('William', $user['firstName']);
-        $this->assertSame('Gates III', $user['lastName']);
-        $this->assertSame('william.gates@example.com', $user['email']);
+        $this->assertSame('Ollie', $user['firstName']);
+        $this->assertSame('Frenchie', $user['lastName']);
+        $this->assertSame('ollie.frenchie@example.com', $user['email']);
     }
 
     /**

--- a/tests/Unit/Application/Users/Services/UserServiceTest.php
+++ b/tests/Unit/Application/Users/Services/UserServiceTest.php
@@ -38,8 +38,8 @@ class UserServiceTest extends TestCase
 
         $this->assertIsArray($users);
         $this->assertCount(5, $users);
-        $this->assertSame('Bill', $users[0]->getFirstName());
-        $this->assertSame('Gates', $users[0]->getLastName());
+        $this->assertSame('Oliver', $users[0]->getFirstName());
+        $this->assertSame('French', $users[0]->getLastName());
     }
 
     /**
@@ -69,9 +69,9 @@ class UserServiceTest extends TestCase
         $user = $this->userService->find(1);
 
         $this->assertSame(1, $user->getId());
-        $this->assertSame('Bill', $user->getFirstName());
-        $this->assertSame('Gates', $user->getLastName());
-        $this->assertSame('billgates@example.com', $user->getEmail());
+        $this->assertSame('Oliver', $user->getFirstName());
+        $this->assertSame('French', $user->getLastName());
+        $this->assertSame('oliver.french@example.com', $user->getEmail());
     }
 
     /**
@@ -93,7 +93,7 @@ class UserServiceTest extends TestCase
         $dto = new UpdateUserDTO(
             id: 1,
             firstName: 'William',
-            lastName: 'Gates III',
+            lastName: 'French III',
             email: 'william.gates@example.com'
         );
 
@@ -101,7 +101,7 @@ class UserServiceTest extends TestCase
 
         $this->assertSame(1, $user->getId());
         $this->assertSame('William', $user->getFirstName());
-        $this->assertSame('Gates III', $user->getLastName());
+        $this->assertSame('French III', $user->getLastName());
         $this->assertSame('william.gates@example.com', $user->getEmail());
     }
 
@@ -119,8 +119,8 @@ class UserServiceTest extends TestCase
 
         $this->assertSame(2, $user->getId());
         $this->assertSame('Stephen', $user->getFirstName());
-        $this->assertSame('Jobs', $user->getLastName());
-        $this->assertSame('stevejobs@example.com', $user->getEmail());
+        $this->assertSame('Anderson', $user->getLastName());
+        $this->assertSame('charlotte.anderson@example.com', $user->getEmail());
     }
 
     /**


### PR DESCRIPTION
This pull request introduces new development and documentation assets, updates the initial in-memory user data, and adds comprehensive HTTP request/response examples for the Users API. The most important changes are summarized below:

**Development and Documentation Assets:**

* Added a new `resources/` directory to the project structure, including a `http/` subdirectory for HTTP examples, as documented in `README.md`.

**User Data Initialization:**

* Updated the initial users in `InMemoryUserRepository` to use new example names and emails, replacing the previous list.

**API Documentation and Testing:**

* Added `resources/http/users.http` containing example HTTP requests for listing, creating, showing, updating, and deleting users, which can be used for API documentation or testing.