### PR TITLE
refactor: :hammer: improve code quality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing! We welcome improvements and suggest
 - [Code of Conduct](#code-of-conduct)
 - [Development Setup](#development-setup)
 - [Environment](#environment)
+- [Configuration](#configuration)
 - [Upgrading Dependencies](#upgrading-dependencies)
 - [Testing](#testing)
 - [Docker](#docker)
@@ -35,6 +36,48 @@ Environment configuration is managed via a `.env` file loaded at runtime using [
 The `.env` file should **never** be committed to version control. In production, set environment variables directly in the hosting environment; when `APP_ENV` is already set, the application skips loading the `.env` file automatically.
 
 > ⚠️ **Important:** When adding a new environment variable, always add a corresponding entry to `.env.example` with a sensible placeholder or default value.
+
+## Configuration
+
+Application configuration is organised inside the `bootstrap/` directory and is loaded during application creation. Each file contributes a specific part of the application wiring without containing runtime or domain logic.
+
+### Settings
+
+Application configuration values and environment mappings are defined in `settings.php`, which provides the base configuration used throughout the application.
+
+This file is typically used for environment-specific configuration values, feature toggles, and structured configuration arrays consumed across the system.
+
+### Dependencies
+
+Service registrations for the dependency injection container are defined in `dependencies.php`, which controls how infrastructure services are constructed and resolved at runtime.
+
+This includes factory closures, external library wiring, and shared service definitions.
+
+### Repositories
+
+Interface to implementation bindings are defined in `repositories.php`, which maps domain contracts to infrastructure implementations.
+
+This ensures the Domain layer remains independent of persistence or external systems.
+
+### Middleware
+
+Custom middleware is registered in `middleware.php`, which applies global and feature-level middleware to the Slim application instance.
+
+Middleware is executed in LIFO order and is responsible for cross-cutting concerns such as authentication and request transformation. Note that error handling middleware is added automatically by the application factory and does not need to be registered here.
+
+### Routes
+
+Slim route definitions are registered in `routes.php`, which attaches HTTP endpoints to their corresponding application actions.
+
+Routes follow RESTful conventions and are typically grouped by feature or domain area. The standard set of routes for a resource is:
+
+| Method   | Path             | Description         |
+| -------- | ---------------- | ------------------- |
+| `GET`    | `/resource`      | List all records    |
+| `POST`   | `/resource`      | Create a new record |
+| `GET`    | `/resource/{id}` | Retrieve a record   |
+| `PUT`    | `/resource/{id}` | Update a record     |
+| `DELETE` | `/resource/{id}` | Delete a record     |
 
 ## Upgrading Dependencies
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -33,10 +33,10 @@ if (!function_exists('get_env')) {
             $value = $_ENV[$key];
 
             switch (strtolower($value)) {
-                case 'true' === $value:
+                case 'true':
                     return true;
 
-                case 'false' === $value:
+                case 'false':
                     return false;
 
                 default:

--- a/bootstrap/routes.php
+++ b/bootstrap/routes.php
@@ -16,9 +16,9 @@ return function(App $app): void {
             $v1->group('/users', function(Group $users) {
                 $users->get('', ListUsersAction::class);
                 $users->post('', CreateUserAction::class);
-                $users->delete('/{id}', DeleteUserAction::class);
                 $users->get('/{id}', ShowUserAction::class);
                 $users->put('/{id}', UpdateUserAction::class);
+                $users->delete('/{id}', DeleteUserAction::class);
             });
         });
     });

--- a/tests/Integration/AbstractIntegrationTestCase.php
+++ b/tests/Integration/AbstractIntegrationTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Integration;
 
 use App\Infrastructure\Application;

--- a/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
@@ -9,7 +9,7 @@ use Tests\Integration\AbstractIntegrationTestCase;
 /**
  * Integration tests for CreateUserAction.
  */
-class CreateUserActionTest extends AbstractIntegrationTestCase
+final class CreateUserActionTest extends AbstractIntegrationTestCase
 {
     /**
      * Asserts that a 201 response with the created user data is returned when valid input is provided.

--- a/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
@@ -9,7 +9,7 @@ use Tests\Integration\AbstractIntegrationTestCase;
 /**
  * Integration tests for DeleteUserAction.
  */
-class DeleteUserActionTest extends AbstractIntegrationTestCase
+final class DeleteUserActionTest extends AbstractIntegrationTestCase
 {
     /**
      * Asserts that a 204 response with an empty body is returned when the user exists.

--- a/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
@@ -9,7 +9,7 @@ use Tests\Integration\AbstractIntegrationTestCase;
 /**
  * Integration tests for ListUsersAction.
  */
-class ListUsersActionTest extends AbstractIntegrationTestCase
+final class ListUsersActionTest extends AbstractIntegrationTestCase
 {
     /**
      * Asserts that a 200 response containing all seeded users is returned.

--- a/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
@@ -9,7 +9,7 @@ use Tests\Integration\AbstractIntegrationTestCase;
 /**
  * Integration tests for ShowUserAction.
  */
-class ShowUserActionTest extends AbstractIntegrationTestCase
+final class ShowUserActionTest extends AbstractIntegrationTestCase
 {
     /**
      * Asserts that a 200 response containing the requested user is returned when the user exists.

--- a/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
@@ -9,7 +9,7 @@ use Tests\Integration\AbstractIntegrationTestCase;
 /**
  * Integration tests for UpdateUserAction.
  */
-class UpdateUserActionTest extends AbstractIntegrationTestCase
+final class UpdateUserActionTest extends AbstractIntegrationTestCase
 {
     /**
      * Asserts that a 200 response containing the updated user data is returned when the user exists.

--- a/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Unit tests for CreateUserDTO.
  */
-class CreateUserDTOTest extends TestCase
+final class CreateUserDTOTest extends TestCase
 {
     /**
      * Asserts that a DTO is successfully created when all required fields are present in the input array.

--- a/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
@@ -33,8 +33,6 @@ final class CreateUserDTOTest extends TestCase
 
     /**
      * Asserts that an InvalidArgumentException is thrown when one or more required fields are absent.
-     *
-     * @dataProvider invalidPayloadProvider
      */
     #[DataProvider('invalidPayloadProvider')]
     public function testThrowsInvalidArgumentExceptionWhenRequiredFieldsAreMissing(array $payload): void
@@ -48,7 +46,7 @@ final class CreateUserDTOTest extends TestCase
     /**
      * Provides input arrays with one or more missing required fields.
      *
-     * @return array<string, array<mixed>> Named sets of invalid payloads.
+     * @return array<string, array> Named sets of invalid payloads.
      */
     public static function invalidPayloadProvider(): array
     {

--- a/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Application\Users\DTOs;
 
 use App\Application\Users\DTOs\CreateUserDTO;

--- a/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/CreateUserDTOTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Application\Users\DTOs;
 
 use App\Application\Users\DTOs\CreateUserDTO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,6 +36,7 @@ final class CreateUserDTOTest extends TestCase
      *
      * @dataProvider invalidPayloadProvider
      */
+    #[DataProvider('invalidPayloadProvider')]
     public function testThrowsInvalidArgumentExceptionWhenRequiredFieldsAreMissing(array $payload): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Unit/Application/Users/DTOs/UpdateUserDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/UpdateUserDTOTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Unit tests for UpdateUserDTO.
  */
-class UpdateUserDTOTest extends TestCase
+final class UpdateUserDTOTest extends TestCase
 {
     /**
      * Asserts that all fields are correctly mapped when a complete input array is provided.

--- a/tests/Unit/Application/Users/DTOs/UpdateUserDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/UpdateUserDTOTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Application\Users\DTOs;
 
 use App\Application\Users\DTOs\UpdateUserDTO;

--- a/tests/Unit/Application/Users/DTOs/UserResponseDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/UserResponseDTOTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Unit tests for UserResponseDTO.
  */
-class UserResponseDTOTest extends TestCase
+final class UserResponseDTOTest extends TestCase
 {
     /**
      * Asserts that the DTO is correctly populated from a domain User entity.

--- a/tests/Unit/Application/Users/DTOs/UserResponseDTOTest.php
+++ b/tests/Unit/Application/Users/DTOs/UserResponseDTOTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Application\Users\DTOs;
 
 use App\Application\Users\DTOs\UserResponseDTO;

--- a/tests/Unit/Application/Users/Services/UserServiceTest.php
+++ b/tests/Unit/Application/Users/Services/UserServiceTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Unit tests for UserService.
  */
-class UserServiceTest extends TestCase
+final class UserServiceTest extends TestCase
 {
     /**
      * @var UserService The service under test, backed by an in-memory repository.

--- a/tests/Unit/Application/Users/Services/UserServiceTest.php
+++ b/tests/Unit/Application/Users/Services/UserServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Application\Users\Services;
 
 use App\Application\Users\DTOs\CreateUserDTO;

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -78,6 +78,46 @@ final class HelpersTest extends TestCase
     }
 
     /**
+     * Asserts that "TRUE" (uppercase) is cast to a boolean true.
+     */
+    public function testGetEnvCastsTrueUppercase(): void
+    {
+        $_ENV['FLAG_KEY'] = 'TRUE';
+
+        $this->assertTrue(get_env('FLAG_KEY'));
+    }
+
+    /**
+     * Asserts that "FALSE" (uppercase) is cast to a boolean false.
+     */
+    public function testGetEnvCastsFalseUppercase(): void
+    {
+        $_ENV['FLAG_KEY'] = 'FALSE';
+
+        $this->assertFalse(get_env('FLAG_KEY'));
+    }
+
+    /**
+     * Asserts that "True" (mixed-case) is cast to a boolean true.
+     */
+    public function testGetEnvCastsTrueMixedCase(): void
+    {
+        $_ENV['FLAG_KEY'] = 'True';
+
+        $this->assertTrue(get_env('FLAG_KEY'));
+    }
+
+    /**
+     * Asserts that "False" (mixed-case) is cast to a boolean false.
+     */
+    public function testGetEnvCastsFalseMixedCase(): void
+    {
+        $_ENV['FLAG_KEY'] = 'False';
+
+        $this->assertFalse(get_env('FLAG_KEY'));
+    }
+
+    /**
      * Asserts that an empty array is returned when the key is missing.
      */
     public function testGetEnvArrayReturnsEmptyWhenMissing(): void


### PR DESCRIPTION
This pull request improves code quality, documentation, and correctness in several areas of the project. The most significant changes are an expanded configuration section in the contributing guide, stricter type and test definitions, and a minor fix in environment variable parsing.

**Documentation improvements:**

* Added a comprehensive "Configuration" section to `CONTRIBUTING.md`, detailing the purpose and contents of each configuration file in the `bootstrap/` directory, including `settings.php`, `dependencies.php`, `repositories.php`, `middleware.php`, and `routes.php`.
* Updated the table of contents in `CONTRIBUTING.md` to include the new "Configuration" section.

**Testing and type safety:**

* Marked all test classes as `final` and added `declare(strict_types=1);` to unit and integration test files for stricter type checking and improved test isolation [[1]](diffhunk://#diff-4602c85769ef1d933c9842b0253dbbe04a1584a465e724035a84cdfc4b51e19eR3-R4) [[2]](diffhunk://#diff-2103669409c3d50ec6fb04c629c492bc9d8c8bd411a84dacc3293598fe494701L12-R12) [[3]](diffhunk://#diff-9402d46bb8c19067b8da4b4537cd6397eb515d43ea78bc53053c9504c7b7dfefL12-R12) [[4]](diffhunk://#diff-58c39df2102ab9ce30ef6909007e7975e1e25addca2e1a47db5de91cf626b2b4L12-R12) [[5]](diffhunk://#diff-1c83a4f1770991564dfe2dc171f877e6b4d16720f74b116ab05b812b002e2b9eL12-R12) [[6]](diffhunk://#diff-26c4f072bc439c59a5439bfdb07d8c49ca27a3f82678f44ea7f67f7064e0945dL12-R12) [[7]](diffhunk://#diff-684a2c3d761d523d91a82ff231861b2f7d66760cd2ed1be1a04a40a3f3e3c782R3-R14) [[8]](diffhunk://#diff-cc421752039d7196da3dc7ffb065e8d166818760d84e40f55d63b9fa6b392458R3-R4) [[9]](diffhunk://#diff-20049c475ab3aa3146c7b7ae59ee423ab727b86ad1b5e2f210e311ec1249fff0R3-R4) [[10]](diffhunk://#diff-35b14a7057f21075e430b4092d72a86913d29bf042af066561d51791531db3caR3-R4).
* Updated PHPUnit data provider usage to use the `#[DataProvider]` attribute instead of the annotation, and improved the return type hint for the provider in `CreateUserDTOTest` [[1]](diffhunk://#diff-684a2c3d761d523d91a82ff231861b2f7d66760cd2ed1be1a04a40a3f3e3c782L33-R37) [[2]](diffhunk://#diff-684a2c3d761d523d91a82ff231861b2f7d66760cd2ed1be1a04a40a3f3e3c782L47-R49).

**Code correctness:**

* Fixed the `get_env` helper function to properly handle boolean string values by correcting the `switch` statement cases.

**Route definition cleanup:**

* Reordered the `delete` route in `bootstrap/routes.php` for consistency.