### PR TITLE
feat: :sparkles: add database bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,29 @@ Routes follow RESTful conventions and are typically grouped by feature or domain
 | `PUT`    | `/resource/{id}` | Update a record     |
 | `DELETE` | `/resource/{id}` | Delete a record     |
 
+### Adding Custom Bootstrap Files
+
+The bootstrap system is extensible — you can add additional files when your application requires setup for concerns not covered by the standard files.
+
+Consider adding a custom bootstrap file when you need to:
+
+- Register event listeners or subscribers
+- Configure command-line commands or scheduled tasks
+- Set up queue workers or job handlers
+- Initialize third-party services with complex setup
+- Configure observability tools (metrics, tracing)
+
+To add a custom bootstrap file:
+
+1. Create a new file in `bootstrap/` (e.g., `events.php`) that returns a closure accepting the `App` instance
+2. Add a corresponding method to `ApplicationFactory` (e.g., `registerEvents()`)
+3. Call the method at the appropriate point in the `build()` lifecycle
+4. Update documentation to reflect the new bootstrap file
+
+The closure should follow the same pattern as existing files — accepting `App $app` and having a `void` return type. Access the container via `$app->getContainer()` when needed.
+
+Avoid creating new bootstrap files for simple configuration — prefer using existing files when possible to maintain clarity and consistency.
+
 ## Upgrading Dependencies
 
 Keeping dependencies up-to-date is crucial for maintaining the security and performance of the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ Interface to implementation bindings are defined in `repositories.php`, which ma
 
 This ensures the Domain layer remains independent of persistence or external systems.
 
+### Database
+
+Database initialisation is configured in `database.php`, which provides a hook for setting up database-related concerns at the appropriate point in the application lifecycle.
+
+This file is intentionally flexible and can be used for establishing connections (PDO, MySQLi), booting ORMs (Eloquent, Doctrine), initialising query builders, running migrations, or any other database setup. The application factory calls this file after the container is built and before routes are registered, giving you access to resolved dependencies while keeping the factory decoupled from specific implementations.
+
 ### Middleware
 
 Custom middleware is registered in `middleware.php`, which applies global and feature-level middleware to the Slim application instance.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ repo/
 │   └── helpers.php              # Global utility functions
 │
 ├── bootstrap/                   # Application configuration layer
+│   ├── database.php             # Database initialisation
 │   ├── dependencies.php         # Container service registrations
 │   ├── middleware.php           # HTTP middleware pipeline configuration
 │   ├── repositories.php         # Interface → implementation bindings
@@ -106,6 +107,8 @@ Configuration values and environment mappings are defined in `settings.php`, whi
 Service registrations for the dependency injection container are defined in `dependencies.php`, which controls how infrastructure services are constructed.
 
 Interface to implementation bindings are defined in `repositories.php`, which maps domain contracts to concrete implementations.
+
+Database initialisation is configured in `database.php`, which provides a hook for setting up database connections, booting ORMs (Eloquent, Doctrine), configuring raw PDO connections, or running migrations.
 
 The HTTP middleware pipeline is configured in `middleware.php`, which defines how incoming requests are processed.
 

--- a/app/Infrastructure/Factory/ApplicationFactory.php
+++ b/app/Infrastructure/Factory/ApplicationFactory.php
@@ -73,6 +73,8 @@ final class ApplicationFactory
 
         $this->registerMiddleware($app, $settings, $errorHandler);
 
+        $this->registerDatabase($app);
+
         $this->registerRoutes($app);
 
         return new Application($app, $emitter);
@@ -230,6 +232,17 @@ final class ApplicationFactory
         );
 
         $errorMiddleware->setDefaultErrorHandler($errorHandler);
+    }
+
+    /**
+     * Registers database configuration on the Slim application.
+     *
+     * @param  App  $app The Slim application.
+     * @return void Returns after database is configured.
+     */
+    private function registerDatabase(App $app): void
+    {
+        require_from_root('bootstrap/database.php')($app);
     }
 
     /**

--- a/bootstrap/database.php
+++ b/bootstrap/database.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Slim\App;
+
+return function (App $app): void {
+    // $container = $app->getContainer();
+
+    // Example: Boot Eloquent (Laravel Database)
+    // $capsule = $container->get(\Illuminate\Database\Capsule\Manager::class);
+    // $capsule->bootEloquent();
+
+    // Example: Set up Doctrine EntityManager
+    // $entityManager = $container->get(\Doctrine\ORM\EntityManagerInterface::class);
+
+    // Example: Configure PDO connection
+    // $pdo = $container->get(\PDO::class);
+};


### PR DESCRIPTION
This pull request introduces a new, flexible database initialization mechanism to the application bootstrap process. It adds a dedicated `database.php` bootstrap file and integrates it into the application factory, allowing for centralized and customizable database setup. The documentation is updated to reflect these changes, and guidance is provided for extending the bootstrap system with custom files.

**Database Initialization Integration**
- Added a new `bootstrap/database.php` file as the standard location for all database setup concerns (e.g., establishing connections, booting ORMs, running migrations). [[1]](diffhunk://#diff-dd2707f2c842e02bc1c244e0967a3c5c7a2c910677a60c198a9405b1f7893d5aR1-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111-R112)
- Updated `ApplicationFactory` to call a new `registerDatabase()` method, which loads and executes the `database.php` bootstrap file during application construction, just after middleware registration and before route registration. [[1]](diffhunk://#diff-2eb1623cb2be7cf0522e45383d9de3b0860b360ab82dd024dd21a78ed978958cR76-R77) [[2]](diffhunk://#diff-2eb1623cb2be7cf0522e45383d9de3b0860b360ab82dd024dd21a78ed978958cR237-R247)

**Documentation Updates**
- Expanded the `README.md` and `CONTRIBUTING.md` to document the new database initialization process, including where and how to configure database-related logic. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111-R112) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R62-R67)
- Added instructions and best practices for adding custom bootstrap files for other application concerns, ensuring extensibility and maintainability of the bootstrap process.