### PR TITLE
refactor: :hammer: enhance user-related tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@
 
 # Ignore environment files
 .env
-.env.backup
+.env.*
+!.env.example
 
 # Ignore generated files
 .php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {
+        "fakerphp/faker": "^1.24",
         "friendsofphp/php-cs-fixer": "^3.94",
         "phpunit/phpunit": "^11.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a9f866a3ea3901485b66498dd381102",
+    "content-hash": "92580881814a4d608d373a654ba5d9db",
     "packages": [
         {
             "name": "andrewdyer/actions",
@@ -2081,6 +2081,69 @@
                 "source": "https://github.com/igorw/evenement/tree/v3.0.2"
             },
             "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",

--- a/tests/Integration/AbstractIntegrationTestCase.php
+++ b/tests/Integration/AbstractIntegrationTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Integration;
 
+use Faker\Factory as FakerFactory;
+use Faker\Generator;
 use JsonException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -23,6 +25,11 @@ abstract class AbstractIntegrationTestCase extends TestCase
     protected App $app;
 
     /**
+     * The Faker generator instance.
+     */
+    protected Generator $faker;
+
+    /**
      * Sets up the application before each test.
      *
      * @return void
@@ -30,6 +37,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
     protected function setUp(): void
     {
         $this->app = require_from_root('bootstrap/app.php')();
+        $this->faker = FakerFactory::create();
     }
 
     /**

--- a/tests/Integration/AbstractTestCase.php
+++ b/tests/Integration/AbstractTestCase.php
@@ -17,7 +17,7 @@ use Slim\Psr7\Uri;
 /**
  * Base class for integration tests using the full application stack.
  */
-abstract class AbstractIntegrationTestCase extends TestCase
+abstract class AbstractTestCase extends TestCase
 {
     /**
      * The application instance under test.

--- a/tests/Integration/AbstractTestCase.php
+++ b/tests/Integration/AbstractTestCase.php
@@ -46,8 +46,8 @@ abstract class AbstractTestCase extends TestCase
      * @param  string                    $method The HTTP method.
      * @param  string                    $path   The request URI path.
      * @param  array<string, mixed>|null $data   Optional JSON request body.
-     * @return ResponseInterface         Returns the application response.
-     * @throws JsonException
+     * @return ResponseInterface         The application response.
+     * @throws JsonException             If JSON encoding fails.
      */
     protected function request(string $method, string $path, ?array $data = null): ResponseInterface
     {

--- a/tests/Integration/AbstractTestCase.php
+++ b/tests/Integration/AbstractTestCase.php
@@ -31,8 +31,6 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * Sets up the application before each test.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -80,8 +78,8 @@ abstract class AbstractTestCase extends TestCase
      * Returns the decoded JSON response body.
      *
      * @param  ResponseInterface    $response The HTTP response.
-     * @return array<string, mixed> Returns the decoded response data.
-     * @throws JsonException
+     * @return array<string, mixed> The decoded response data.
+     * @throws JsonException        If JSON decoding fails.
      */
     protected function decodeJson(ResponseInterface $response): array
     {

--- a/tests/Integration/Application/Users/AbstractUsersTestCase.php
+++ b/tests/Integration/Application/Users/AbstractUsersTestCase.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Application\Users;
+
+use App\Domain\User\UserRepository;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Tests\Integration\AbstractIntegrationTestCase;
+use Tests\Support\Factories\UserFactory;
+
+/**
+ * Base class for User-related integration tests.
+ *
+ * Provides shared setup for UserRepository and UserFactory.
+ */
+abstract class AbstractUsersTestCase extends AbstractIntegrationTestCase
+{
+    /**
+     * The user repository instance.
+     */
+    protected UserRepository $userRepository;
+
+    /**
+     * The user factory instance.
+     */
+    protected UserFactory $userFactory;
+
+    /**
+     * Sets up the test dependencies before each test.
+     *
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userRepository = $this->app
+            ->getContainer()
+            ->get(UserRepository::class);
+
+        $this->userFactory = new UserFactory(
+            $this->userRepository,
+            $this->faker
+        );
+    }
+}

--- a/tests/Integration/Application/Users/AbstractUsersTestCase.php
+++ b/tests/Integration/Application/Users/AbstractUsersTestCase.php
@@ -7,7 +7,7 @@ namespace Tests\Integration\Application\Users;
 use App\Domain\User\UserRepository;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use Tests\Integration\AbstractIntegrationTestCase;
+use Tests\Integration\AbstractTestCase;
 use Tests\Support\Factories\UserFactory;
 
 /**
@@ -15,7 +15,7 @@ use Tests\Support\Factories\UserFactory;
  *
  * Provides shared setup for UserRepository and UserFactory.
  */
-abstract class AbstractUsersTestCase extends AbstractIntegrationTestCase
+abstract class AbstractUsersTestCase extends AbstractTestCase
 {
     /**
      * The user repository instance.

--- a/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
@@ -32,11 +32,11 @@ final class CreateUserActionTest extends AbstractIntegrationTestCase
 
         $this->assertArrayHasKey('data', $body);
 
-        $user = $body['data'];
-        $this->assertIsInt($user['id']);
-        $this->assertSame($firstName, $user['firstName']);
-        $this->assertSame($lastName, $user['lastName']);
-        $this->assertSame($email, $user['email']);
+        $data = $body['data'];
+        $this->assertIsInt($data['id']);
+        $this->assertSame($firstName, $data['firstName']);
+        $this->assertSame($lastName, $data['lastName']);
+        $this->assertSame($email, $data['email']);
     }
 
     /**

--- a/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
@@ -16,10 +16,14 @@ final class CreateUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns201WhenDataIsValid(): void
     {
+        $firstName = $this->faker->firstName();
+        $lastName = $this->faker->lastName();
+        $email = $this->faker->unique()->safeEmail();
+
         $response = $this->request('POST', '/api/v1/users', [
-            'first_name' => 'Jane',
-            'last_name' => 'Doe',
-            'email' => 'jane@example.com',
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'email' => $email,
         ]);
 
         $this->assertSame(201, $response->getStatusCode());
@@ -30,9 +34,9 @@ final class CreateUserActionTest extends AbstractIntegrationTestCase
 
         $user = $body['data'];
         $this->assertIsInt($user['id']);
-        $this->assertSame('Jane', $user['firstName']);
-        $this->assertSame('Doe', $user['lastName']);
-        $this->assertSame('jane@example.com', $user['email']);
+        $this->assertSame($firstName, $user['firstName']);
+        $this->assertSame($lastName, $user['lastName']);
+        $this->assertSame($email, $user['email']);
     }
 
     /**

--- a/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/CreateUserActionTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
-use Tests\Integration\AbstractIntegrationTestCase;
+use Tests\Integration\Application\Users\AbstractUsersTestCase;
 
 /**
  * Integration tests for CreateUserAction.
  */
-final class CreateUserActionTest extends AbstractIntegrationTestCase
+final class CreateUserActionTest extends AbstractUsersTestCase
 {
     /**
      * Asserts that a 201 response with the created user data is returned when valid input is provided.

--- a/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
@@ -11,7 +11,6 @@ use Tests\Integration\Application\Users\AbstractUsersTestCase;
  */
 final class DeleteUserActionTest extends AbstractUsersTestCase
 {
-
     /**
      * Asserts that a 204 response is returned when the user exists.
      */
@@ -22,7 +21,6 @@ final class DeleteUserActionTest extends AbstractUsersTestCase
         $response = $this->request('DELETE', '/api/v1/users/' . $user->getId());
 
         $this->assertSame(204, $response->getStatusCode());
-        $this->assertSame([], $this->decodeJson($response));
     }
 
     /**

--- a/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
@@ -13,7 +13,7 @@ final class DeleteUserActionTest extends AbstractUsersTestCase
 {
 
     /**
-     * Asserts that a 204 response with an empty body is returned when the user exists.
+     * Asserts that a 204 response is returned when the user exists.
      */
     public function testReturns204WhenUserExists(): void
     {

--- a/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
+use App\Domain\User\UserRepository;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Tests\Integration\AbstractIntegrationTestCase;
+use Tests\Support\Factories\UserFactory;
 
 /**
  * Integration tests for DeleteUserAction.
@@ -12,11 +16,48 @@ use Tests\Integration\AbstractIntegrationTestCase;
 final class DeleteUserActionTest extends AbstractIntegrationTestCase
 {
     /**
+     * The user repository instance.
+     */
+    private UserRepository $users;
+
+    /**
+     * The user factory instance.
+     */
+    private UserFactory $user;
+
+    /**
+     * Sets up the test dependencies before each test.
+     *
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->users = $this->app
+            ->getContainer()
+            ->get(UserRepository::class);
+
+        $this->user = new UserFactory(
+            $this->users,
+            $this->faker
+        );
+    }
+
+    /**
      * Asserts that a 204 response with an empty body is returned when the user exists.
      */
     public function testReturns204WhenUserExists(): void
     {
-        $response = $this->request('DELETE', '/api/v1/users/1');
+        $user = $this->user->create([
+            'firstName' => $this->faker->firstName(),
+            'lastName' => $this->faker->lastName(),
+            'email' => $this->faker->unique()->safeEmail(),
+        ]);
+
+        $response = $this->request('DELETE', '/api/v1/users/' . $user->getId());
 
         $this->assertSame(204, $response->getStatusCode());
         $this->assertSame([], $this->decodeJson($response));
@@ -27,9 +68,15 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns204WhenUserDoesNotExist(): void
     {
-        // DeleteUserAction does not throw on a missing ID — the repository
-        // returns false silently and the action always responds 204.
-        $response = $this->request('DELETE', '/api/v1/users/999');
+        $user = $this->user->create([
+            'firstName' => $this->faker->firstName(),
+            'lastName' => $this->faker->lastName(),
+            'email' => $this->faker->unique()->safeEmail(),
+        ]);
+
+        $this->users->delete($user->getId());
+
+        $response = $this->request('DELETE', '/api/v1/users/' . $user->getId());
 
         $this->assertSame(204, $response->getStatusCode());
     }

--- a/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
@@ -4,47 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
-use App\Domain\User\UserRepository;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use Tests\Integration\AbstractIntegrationTestCase;
-use Tests\Support\Factories\UserFactory;
+use Tests\Integration\Application\Users\AbstractUsersTestCase;
 
 /**
  * Integration tests for DeleteUserAction.
  */
-final class DeleteUserActionTest extends AbstractIntegrationTestCase
+final class DeleteUserActionTest extends AbstractUsersTestCase
 {
-    /**
-     * The user repository instance.
-     */
-    private UserRepository $users;
-
-    /**
-     * The user factory instance.
-     */
-    private UserFactory $userFactory;
-
-    /**
-     * Sets up the test dependencies before each test.
-     *
-     * @return void
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->users = $this->app
-            ->getContainer()
-            ->get(UserRepository::class);
-
-        $this->userFactory = new UserFactory(
-            $this->users,
-            $this->faker
-        );
-    }
 
     /**
      * Asserts that a 204 response with an empty body is returned when the user exists.
@@ -66,7 +32,7 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
     {
         $user = $this->userFactory->create();
 
-        $this->users->delete($user->getId());
+        $this->userRepository->delete($user->getId());
 
         $response = $this->request('DELETE', '/api/v1/users/' . $user->getId());
 

--- a/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
@@ -51,11 +51,7 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns204WhenUserExists(): void
     {
-        $user = $this->user->create([
-            'firstName' => $this->faker->firstName(),
-            'lastName' => $this->faker->lastName(),
-            'email' => $this->faker->unique()->safeEmail(),
-        ]);
+        $user = $this->user->create();
 
         $response = $this->request('DELETE', '/api/v1/users/' . $user->getId());
 
@@ -68,11 +64,7 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns204WhenUserDoesNotExist(): void
     {
-        $user = $this->user->create([
-            'firstName' => $this->faker->firstName(),
-            'lastName' => $this->faker->lastName(),
-            'email' => $this->faker->unique()->safeEmail(),
-        ]);
+        $user = $this->user->create();
 
         $this->users->delete($user->getId());
 

--- a/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/DeleteUserActionTest.php
@@ -23,7 +23,7 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
     /**
      * The user factory instance.
      */
-    private UserFactory $user;
+    private UserFactory $userFactory;
 
     /**
      * Sets up the test dependencies before each test.
@@ -40,7 +40,7 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
             ->getContainer()
             ->get(UserRepository::class);
 
-        $this->user = new UserFactory(
+        $this->userFactory = new UserFactory(
             $this->users,
             $this->faker
         );
@@ -51,7 +51,7 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns204WhenUserExists(): void
     {
-        $user = $this->user->create();
+        $user = $this->userFactory->create();
 
         $response = $this->request('DELETE', '/api/v1/users/' . $user->getId());
 
@@ -64,7 +64,7 @@ final class DeleteUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns204WhenUserDoesNotExist(): void
     {
-        $user = $this->user->create();
+        $user = $this->userFactory->create();
 
         $this->users->delete($user->getId());
 

--- a/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
+use App\Domain\User\UserRepository;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Tests\Integration\AbstractIntegrationTestCase;
+use Tests\Support\Factories\UserFactory;
 
 /**
  * Integration tests for ListUsersAction.
@@ -12,10 +16,44 @@ use Tests\Integration\AbstractIntegrationTestCase;
 final class ListUsersActionTest extends AbstractIntegrationTestCase
 {
     /**
+     * The user repository instance.
+     */
+    private UserRepository $users;
+
+    /**
+     * The user factory instance.
+     */
+    private UserFactory $user;
+
+    /**
+     * Sets up the test dependencies before each test.
+     *
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->users = $this->app
+            ->getContainer()
+            ->get(UserRepository::class);
+
+        $this->user = new UserFactory(
+            $this->users,
+            $this->faker
+        );
+    }
+
+    /**
      * Asserts that a 200 response containing all seeded users is returned.
      */
     public function testReturns200WithAllUsersWhenRequested(): void
     {
+        $firstUser = $this->user->create();
+        $secondUser = $this->user->create();
+
         $response = $this->request('GET', '/api/v1/users');
 
         $this->assertSame(200, $response->getStatusCode());
@@ -23,8 +61,16 @@ final class ListUsersActionTest extends AbstractIntegrationTestCase
         $body = $this->decodeJson($response);
 
         $this->assertArrayHasKey('data', $body);
-        $this->assertIsArray($body['data']);
-        $this->assertCount(5, $body['data']);
+
+        $data = $body['data'];
+
+        $emails = [];
+        foreach ($data as $user) {
+            $emails[] = $user['email'];
+        }
+
+        $this->assertContains($firstUser->getEmail(), $emails);
+        $this->assertContains($secondUser->getEmail(), $emails);
     }
 
     /**
@@ -32,19 +78,37 @@ final class ListUsersActionTest extends AbstractIntegrationTestCase
      */
     public function testReturnsExpectedUserStructureWhenUsersExist(): void
     {
+        $user = $this->user->create();
+
         $response = $this->request('GET', '/api/v1/users');
+
+        $this->assertSame(200, $response->getStatusCode());
+
         $body = $this->decodeJson($response);
 
-        $first = $body['data'][0];
+        $this->assertArrayHasKey('data', $body);
 
-        $this->assertArrayHasKey('id', $first);
-        $this->assertArrayHasKey('firstName', $first);
-        $this->assertArrayHasKey('lastName', $first);
-        $this->assertArrayHasKey('email', $first);
+        $data = $body['data'];
 
-        $this->assertSame(1, $first['id']);
-        $this->assertSame('Oliver', $first['firstName']);
-        $this->assertSame('French', $first['lastName']);
-        $this->assertSame('oliver.french@example.com', $first['email']);
+        $returnedUser = null;
+
+        foreach ($data as $item) {
+            if ($item['id'] === $user->getId()) {
+                $returnedUser = $item;
+                break;
+            }
+        }
+
+        $this->assertNotNull($returnedUser);
+
+        $this->assertArrayHasKey('id', $returnedUser);
+        $this->assertArrayHasKey('firstName', $returnedUser);
+        $this->assertArrayHasKey('lastName', $returnedUser);
+        $this->assertArrayHasKey('email', $returnedUser);
+
+        $this->assertSame($user->getId(), $returnedUser['id']);
+        $this->assertSame($user->getFirstName(), $returnedUser['firstName']);
+        $this->assertSame($user->getLastName(), $returnedUser['lastName']);
+        $this->assertSame($user->getEmail(), $returnedUser['email']);
     }
 }

--- a/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
@@ -4,48 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
-use App\Domain\User\UserRepository;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use Tests\Integration\AbstractIntegrationTestCase;
-use Tests\Support\Factories\UserFactory;
+use Tests\Integration\Application\Users\AbstractUsersTestCase;
 
 /**
  * Integration tests for ListUsersAction.
  */
-final class ListUsersActionTest extends AbstractIntegrationTestCase
+final class ListUsersActionTest extends AbstractUsersTestCase
 {
-    /**
-     * The user repository instance.
-     */
-    private UserRepository $users;
-
-    /**
-     * The user factory instance.
-     */
-    private UserFactory $userFactory;
-
-    /**
-     * Sets up the test dependencies before each test.
-     *
-     * @return void
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->users = $this->app
-            ->getContainer()
-            ->get(UserRepository::class);
-
-        $this->userFactory = new UserFactory(
-            $this->users,
-            $this->faker
-        );
-    }
-
     /**
      * Asserts that a 200 response containing all seeded users is returned.
      */

--- a/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
@@ -23,7 +23,7 @@ final class ListUsersActionTest extends AbstractIntegrationTestCase
     /**
      * The user factory instance.
      */
-    private UserFactory $user;
+    private UserFactory $userFactory;
 
     /**
      * Sets up the test dependencies before each test.
@@ -40,7 +40,7 @@ final class ListUsersActionTest extends AbstractIntegrationTestCase
             ->getContainer()
             ->get(UserRepository::class);
 
-        $this->user = new UserFactory(
+        $this->userFactory = new UserFactory(
             $this->users,
             $this->faker
         );
@@ -51,8 +51,8 @@ final class ListUsersActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns200WithAllUsersWhenRequested(): void
     {
-        $firstUser = $this->user->create();
-        $secondUser = $this->user->create();
+        $firstUser = $this->userFactory->create();
+        $secondUser = $this->userFactory->create();
 
         $response = $this->request('GET', '/api/v1/users');
 
@@ -78,7 +78,7 @@ final class ListUsersActionTest extends AbstractIntegrationTestCase
      */
     public function testReturnsExpectedUserStructureWhenUsersExist(): void
     {
-        $user = $this->user->create();
+        $user = $this->userFactory->create();
 
         $response = $this->request('GET', '/api/v1/users');
 

--- a/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
@@ -29,10 +29,7 @@ final class ListUsersActionTest extends AbstractUsersTestCase
 
         $data = $body['data'];
 
-        $emails = [];
-        foreach ($data as $user) {
-            $emails[] = $user['email'];
-        }
+        $emails = array_column($data, 'email');
 
         $this->assertContains($firstUser->getEmail(), $emails);
         $this->assertContains($secondUser->getEmail(), $emails);

--- a/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ListUsersActionTest.php
@@ -37,43 +37,4 @@ final class ListUsersActionTest extends AbstractUsersTestCase
         $this->assertContains($firstUser->getEmail(), $emails);
         $this->assertContains($secondUser->getEmail(), $emails);
     }
-
-    /**
-     * Asserts that each user in the response contains the expected fields and values.
-     */
-    public function testReturnsExpectedUserStructureWhenUsersExist(): void
-    {
-        $user = $this->userFactory->create();
-
-        $response = $this->request('GET', '/api/v1/users');
-
-        $this->assertSame(200, $response->getStatusCode());
-
-        $body = $this->decodeJson($response);
-
-        $this->assertArrayHasKey('data', $body);
-
-        $data = $body['data'];
-
-        $returnedUser = null;
-
-        foreach ($data as $item) {
-            if ($item['id'] === $user->getId()) {
-                $returnedUser = $item;
-                break;
-            }
-        }
-
-        $this->assertNotNull($returnedUser);
-
-        $this->assertArrayHasKey('id', $returnedUser);
-        $this->assertArrayHasKey('firstName', $returnedUser);
-        $this->assertArrayHasKey('lastName', $returnedUser);
-        $this->assertArrayHasKey('email', $returnedUser);
-
-        $this->assertSame($user->getId(), $returnedUser['id']);
-        $this->assertSame($user->getFirstName(), $returnedUser['firstName']);
-        $this->assertSame($user->getLastName(), $returnedUser['lastName']);
-        $this->assertSame($user->getEmail(), $returnedUser['email']);
-    }
 }

--- a/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
@@ -11,7 +11,6 @@ use Tests\Integration\Application\Users\AbstractUsersTestCase;
  */
 final class ShowUserActionTest extends AbstractUsersTestCase
 {
-
     /**
      * Asserts that a 200 response containing the requested user is returned when the user exists.
      */

--- a/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
@@ -23,7 +23,7 @@ final class ShowUserActionTest extends AbstractIntegrationTestCase
     /**
      * The user factory instance.
      */
-    private UserFactory $user;
+    private UserFactory $userFactory;
 
     /**
      * Sets up the test dependencies before each test.
@@ -40,7 +40,7 @@ final class ShowUserActionTest extends AbstractIntegrationTestCase
             ->getContainer()
             ->get(UserRepository::class);
 
-        $this->user = new UserFactory(
+        $this->userFactory = new UserFactory(
             $this->users,
             $this->faker
         );
@@ -51,7 +51,7 @@ final class ShowUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns200WithUserWhenUserExists(): void
     {
-        $user = $this->user->create();
+        $user = $this->userFactory->create();
 
         $response = $this->request('GET', '/api/v1/users/' . $user->getId());
 
@@ -73,7 +73,7 @@ final class ShowUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns404WhenUserNotFound(): void
     {
-        $user = $this->user->create();
+        $user = $this->userFactory->create();
 
         $this->users->delete($user->getId());
 

--- a/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
+use App\Domain\User\UserRepository;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Tests\Integration\AbstractIntegrationTestCase;
+use Tests\Support\Factories\UserFactory;
 
 /**
  * Integration tests for ShowUserAction.
@@ -12,11 +16,44 @@ use Tests\Integration\AbstractIntegrationTestCase;
 final class ShowUserActionTest extends AbstractIntegrationTestCase
 {
     /**
+     * The user repository instance.
+     */
+    private UserRepository $users;
+
+    /**
+     * The user factory instance.
+     */
+    private UserFactory $user;
+
+    /**
+     * Sets up the test dependencies before each test.
+     *
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->users = $this->app
+            ->getContainer()
+            ->get(UserRepository::class);
+
+        $this->user = new UserFactory(
+            $this->users,
+            $this->faker
+        );
+    }
+
+    /**
      * Asserts that a 200 response containing the requested user is returned when the user exists.
      */
     public function testReturns200WithUserWhenUserExists(): void
     {
-        $response = $this->request('GET', '/api/v1/users/1');
+        $user = $this->user->create();
+
+        $response = $this->request('GET', '/api/v1/users/' . $user->getId());
 
         $this->assertSame(200, $response->getStatusCode());
 
@@ -24,11 +61,11 @@ final class ShowUserActionTest extends AbstractIntegrationTestCase
 
         $this->assertArrayHasKey('data', $body);
 
-        $user = $body['data'];
-        $this->assertSame(1, $user['id']);
-        $this->assertSame('Oliver', $user['firstName']);
-        $this->assertSame('French', $user['lastName']);
-        $this->assertSame('oliver.french@example.com', $user['email']);
+        $data = $body['data'];
+        $this->assertSame($user->getId(), $data['id']);
+        $this->assertSame($user->getFirstName(), $data['firstName']);
+        $this->assertSame($user->getLastName(), $data['lastName']);
+        $this->assertSame($user->getEmail(), $data['email']);
     }
 
     /**
@@ -36,7 +73,11 @@ final class ShowUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns404WhenUserNotFound(): void
     {
-        $response = $this->request('GET', '/api/v1/users/999');
+        $user = $this->user->create();
+
+        $this->users->delete($user->getId());
+
+        $response = $this->request('GET', '/api/v1/users/' . $user->getId());
 
         $this->assertSame(404, $response->getStatusCode());
     }

--- a/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/ShowUserActionTest.php
@@ -4,47 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
-use App\Domain\User\UserRepository;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use Tests\Integration\AbstractIntegrationTestCase;
-use Tests\Support\Factories\UserFactory;
+use Tests\Integration\Application\Users\AbstractUsersTestCase;
 
 /**
  * Integration tests for ShowUserAction.
  */
-final class ShowUserActionTest extends AbstractIntegrationTestCase
+final class ShowUserActionTest extends AbstractUsersTestCase
 {
-    /**
-     * The user repository instance.
-     */
-    private UserRepository $users;
-
-    /**
-     * The user factory instance.
-     */
-    private UserFactory $userFactory;
-
-    /**
-     * Sets up the test dependencies before each test.
-     *
-     * @return void
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->users = $this->app
-            ->getContainer()
-            ->get(UserRepository::class);
-
-        $this->userFactory = new UserFactory(
-            $this->users,
-            $this->faker
-        );
-    }
 
     /**
      * Asserts that a 200 response containing the requested user is returned when the user exists.
@@ -75,7 +41,7 @@ final class ShowUserActionTest extends AbstractIntegrationTestCase
     {
         $user = $this->userFactory->create();
 
-        $this->users->delete($user->getId());
+        $this->userRepository->delete($user->getId());
 
         $response = $this->request('GET', '/api/v1/users/' . $user->getId());
 

--- a/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
+use App\Domain\User\UserRepository;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Tests\Integration\AbstractIntegrationTestCase;
+use Tests\Support\Factories\UserFactory;
 
 /**
  * Integration tests for UpdateUserAction.
@@ -12,14 +16,51 @@ use Tests\Integration\AbstractIntegrationTestCase;
 final class UpdateUserActionTest extends AbstractIntegrationTestCase
 {
     /**
+     * The user repository instance.
+     */
+    private UserRepository $users;
+
+    /**
+     * The user factory instance.
+     */
+    private UserFactory $user;
+
+    /**
+     * Sets up the test dependencies before each test.
+     *
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->users = $this->app
+            ->getContainer()
+            ->get(UserRepository::class);
+
+        $this->user = new UserFactory(
+            $this->users,
+            $this->faker
+        );
+    }
+
+    /**
      * Asserts that a 200 response containing the updated user data is returned when the user exists.
      */
     public function testReturns200WithUpdatedUserWhenUserExists(): void
     {
-        $response = $this->request('PUT', '/api/v1/users/1', [
-            'first_name' => 'Ollie',
-            'last_name' => 'Frenchie',
-            'email' => 'ollie.frenchie@example.com',
+        $user = $this->user->create();
+
+        $updatedFirstName = $this->faker->firstName();
+        $updatedLastName = $this->faker->lastName();
+        $updatedEmail = $this->faker->unique()->safeEmail();
+
+        $response = $this->request('PUT', '/api/v1/users/' . $user->getId(), [
+            'first_name' => $updatedFirstName,
+            'last_name' => $updatedLastName,
+            'email' => $updatedEmail,
         ]);
 
         $this->assertSame(200, $response->getStatusCode());
@@ -28,11 +69,11 @@ final class UpdateUserActionTest extends AbstractIntegrationTestCase
 
         $this->assertArrayHasKey('data', $body);
 
-        $user = $body['data'];
-        $this->assertSame(1, $user['id']);
-        $this->assertSame('Ollie', $user['firstName']);
-        $this->assertSame('Frenchie', $user['lastName']);
-        $this->assertSame('ollie.frenchie@example.com', $user['email']);
+        $data = $body['data'];
+        $this->assertSame($user->getId(), $data['id']);
+        $this->assertSame($updatedFirstName, $data['firstName']);
+        $this->assertSame($updatedLastName, $data['lastName']);
+        $this->assertSame($updatedEmail, $data['email']);
     }
 
     /**
@@ -40,7 +81,11 @@ final class UpdateUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns404WhenUserNotFound(): void
     {
-        $response = $this->request('PUT', '/api/v1/users/999', [
+        $user = $this->user->create();
+
+        $this->users->delete($user->getId());
+
+        $response = $this->request('PUT', '/api/v1/users/' . $user->getId(), [
             'first_name' => 'Ghost',
         ]);
 

--- a/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
@@ -4,47 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Application\Users\Actions;
 
-use App\Domain\User\UserRepository;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use Tests\Integration\AbstractIntegrationTestCase;
-use Tests\Support\Factories\UserFactory;
+use Tests\Integration\Application\Users\AbstractUsersTestCase;
 
 /**
  * Integration tests for UpdateUserAction.
  */
-final class UpdateUserActionTest extends AbstractIntegrationTestCase
+final class UpdateUserActionTest extends AbstractUsersTestCase
 {
-    /**
-     * The user repository instance.
-     */
-    private UserRepository $users;
-
-    /**
-     * The user factory instance.
-     */
-    private UserFactory $userFactory;
-
-    /**
-     * Sets up the test dependencies before each test.
-     *
-     * @return void
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->users = $this->app
-            ->getContainer()
-            ->get(UserRepository::class);
-
-        $this->userFactory = new UserFactory(
-            $this->users,
-            $this->faker
-        );
-    }
 
     /**
      * Asserts that a 200 response containing the updated user data is returned when the user exists.
@@ -83,7 +49,7 @@ final class UpdateUserActionTest extends AbstractIntegrationTestCase
     {
         $user = $this->userFactory->create();
 
-        $this->users->delete($user->getId());
+        $this->userRepository->delete($user->getId());
 
         $response = $this->request('PUT', '/api/v1/users/' . $user->getId(), [
             'first_name' => 'Ghost',

--- a/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
@@ -11,7 +11,6 @@ use Tests\Integration\Application\Users\AbstractUsersTestCase;
  */
 final class UpdateUserActionTest extends AbstractUsersTestCase
 {
-
     /**
      * Asserts that a 200 response containing the updated user data is returned when the user exists.
      */

--- a/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
+++ b/tests/Integration/Application/Users/Actions/UpdateUserActionTest.php
@@ -23,7 +23,7 @@ final class UpdateUserActionTest extends AbstractIntegrationTestCase
     /**
      * The user factory instance.
      */
-    private UserFactory $user;
+    private UserFactory $userFactory;
 
     /**
      * Sets up the test dependencies before each test.
@@ -40,7 +40,7 @@ final class UpdateUserActionTest extends AbstractIntegrationTestCase
             ->getContainer()
             ->get(UserRepository::class);
 
-        $this->user = new UserFactory(
+        $this->userFactory = new UserFactory(
             $this->users,
             $this->faker
         );
@@ -51,7 +51,7 @@ final class UpdateUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns200WithUpdatedUserWhenUserExists(): void
     {
-        $user = $this->user->create();
+        $user = $this->userFactory->create();
 
         $updatedFirstName = $this->faker->firstName();
         $updatedLastName = $this->faker->lastName();
@@ -81,7 +81,7 @@ final class UpdateUserActionTest extends AbstractIntegrationTestCase
      */
     public function testReturns404WhenUserNotFound(): void
     {
-        $user = $this->user->create();
+        $user = $this->userFactory->create();
 
         $this->users->delete($user->getId());
 

--- a/tests/Support/Factories/UserFactory.php
+++ b/tests/Support/Factories/UserFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Factories;
+
+use App\Domain\User\User;
+use App\Domain\User\UserRepository;
+use Faker\Generator;
+
+/**
+ * Factory for creating test User entities with generated or overridden data.
+ */
+final readonly class UserFactory
+{
+    /**
+     * Constructs a new UserFactory with the given repository and faker instance.
+     *
+     * @param UserRepository $users The repository used to persist created users.
+     * @param Generator      $faker The Faker generator for creating random data.
+     */
+    public function __construct(
+        private UserRepository $users,
+        private Generator      $faker,
+    ) {
+    }
+
+    /**
+     * Creates a new user with generated data, allowing selective overrides.
+     *
+     * @param  array<string, mixed> $overrides Optional field overrides (firstName, lastName, email).
+     * @return User                 The newly created User entity.
+     */
+    public function create(array $overrides = []): User
+    {
+        return $this->users->create(
+            firstName: $overrides['firstName'] ?? $this->faker->firstName(),
+            lastName: $overrides['lastName'] ?? $this->faker->lastName(),
+            email: $overrides['email'] ?? $this->faker->unique()->safeEmail(),
+        );
+    }
+}

--- a/tests/Unit/Application/Users/Services/UserServiceTest.php
+++ b/tests/Unit/Application/Users/Services/UserServiceTest.php
@@ -22,7 +22,7 @@ final class UserServiceTest extends TestCase
     private UserService $userService;
 
     /**
-     * Initialises a fresh UserService instance backed by an in-memory repository before each test.
+     * Initializes a fresh UserService instance backed by an in-memory repository before each test.
      */
     protected function setUp(): void
     {

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\TestCase;
 final class HelpersTest extends TestCase
 {
     /**
-     * Backup of the original $_ENV array.
-     * @var array
+     * Backup of the original environment variables array.
      */
     private array $originalEnv;
 


### PR DESCRIPTION
This pull request refactors and improves the integration test suite for user-related actions. The changes introduce a reusable user test base class and a user factory, leverage the Faker library for generating test data, and update test cases to use dynamically generated data instead of hardcoded values. This results in more maintainable, realistic, and isolated tests.

**Test Infrastructure Improvements:**

* Added `fakerphp/faker` as a development dependency in `composer.json` to enable random test data generation.
* Introduced a `UserFactory` (`tests/Support/Factories/UserFactory.php`) for creating test users with generated or overridden data.
* Created `AbstractUsersTestCase` (`tests/Integration/Application/Users/AbstractUsersTestCase.php`) as a base class for user-related integration tests, providing shared setup for `UserRepository` and `UserFactory`.
* Refactored the main integration test base class: renamed to `AbstractTestCase`, added a `Faker` instance, and initialized it in `setUp()`. [[1]](diffhunk://#diff-1be29371e8fd255c479aae65384e59ff30310b23285c230c279ef54eca5acb57R7-R8) [[2]](diffhunk://#diff-1be29371e8fd255c479aae65384e59ff30310b23285c230c279ef54eca5acb57L18-R31) [[3]](diffhunk://#diff-1be29371e8fd255c479aae65384e59ff30310b23285c230c279ef54eca5acb57R40)

**Test Case Refactoring:**

* Updated all user-related integration tests to extend `AbstractUsersTestCase` and utilize `UserFactory` and `Faker` for user creation and test data, replacing hardcoded values with dynamically generated data. This affects tests for creating, listing, showing, updating, and deleting users. [[1]](diffhunk://#diff-2103669409c3d50ec6fb04c629c492bc9d8c8bd411a84dacc3293598fe494701L7-R26) [[2]](diffhunk://#diff-2103669409c3d50ec6fb04c629c492bc9d8c8bd411a84dacc3293598fe494701L31-R39) [[3]](diffhunk://#diff-9402d46bb8c19067b8da4b4537cd6397eb515d43ea78bc53053c9504c7b7dfefL7-R35) [[4]](diffhunk://#diff-58c39df2102ab9ce30ef6909007e7975e1e25addca2e1a47db5de91cf626b2b4L7-R35) [[5]](diffhunk://#diff-1c83a4f1770991564dfe2dc171f877e6b4d16720f74b116ab05b812b002e2b9eL7-R45) [[6]](diffhunk://#diff-26c4f072bc439c59a5439bfdb07d8c49ca27a3f82678f44ea7f67f7064e0945dL7-R28) [[7]](diffhunk://#diff-26c4f072bc439c59a5439bfdb07d8c49ca27a3f82678f44ea7f67f7064e0945dL31-R53)