### PR TITLE
refactor: reorder methods

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -62,6 +62,10 @@ return $config->setRules([
     'no_whitespace_in_blank_line' => true,
     'normalize_index_brace' => true,
     'object_operator_without_whitespace' => true,
+    'ordered_class_elements' => [
+        'order' => ['property', 'method'],
+        'sort_algorithm' => 'alpha',
+    ],
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
     'phpdoc_align' => ['align' => 'vertical'],
     'phpdoc_indent' => true,

--- a/app/Domain/Repositories/UserRepositoryInterface.php
+++ b/app/Domain/Repositories/UserRepositoryInterface.php
@@ -37,6 +37,14 @@ interface UserRepositoryInterface
     public function findAll(): array;
 
     /**
+     * Returns a user by their unique identifier.
+     *
+     * @param  int       $id The unique identifier of the user to retrieve.
+     * @return User|null The matching User entity, or null if not found.
+     */
+    public function findById(int $id): ?User;
+
+    /**
      * Returns a paginated subset of users.
      *
      * @param  int                              $page    The page number to retrieve (1-indexed).
@@ -44,14 +52,6 @@ interface UserRepositoryInterface
      * @return array{users: User[], total: int} An array containing the users for the requested page and the total count.
      */
     public function findPaginated(int $page, int $perPage): array;
-
-    /**
-     * Returns a user by their unique identifier.
-     *
-     * @param  int       $id The unique identifier of the user to retrieve.
-     * @return User|null The matching User entity, or null if not found.
-     */
-    public function findById(int $id): ?User;
 
     /**
      * Updates an existing user's details and returns the updated entity.

--- a/app/Infrastructure/Persistence/Models/EloquentUserModel.php
+++ b/app/Infrastructure/Persistence/Models/EloquentUserModel.php
@@ -14,13 +14,6 @@ use Illuminate\Database\Eloquent\Model;
 final class EloquentUserModel extends Model
 {
     /**
-     * The table associated with the model.
-     *
-     * @var string The table name used by Eloquent.
-     */
-    protected $table = 'users';
-
-    /**
      * The attributes that are mass assignable.
      *
      * @var array<int, string>
@@ -30,6 +23,12 @@ final class EloquentUserModel extends Model
         'last_name',
         'email',
     ];
+    /**
+     * The table associated with the model.
+     *
+     * @var string The table name used by Eloquent.
+     */
+    protected $table = 'users';
 
     /**
      * Indicates if the model should be timestamped.

--- a/app/Infrastructure/Persistence/Repositories/EloquentUserRepository.php
+++ b/app/Infrastructure/Persistence/Repositories/EloquentUserRepository.php
@@ -64,6 +64,23 @@ final class EloquentUserRepository implements UserRepositoryInterface
     }
 
     /**
+     * Returns a user by their unique identifier.
+     *
+     * @param  int       $id The unique identifier of the user to retrieve.
+     * @return User|null The matching User entity, or null if not found.
+     */
+    public function findById(int $id): ?User
+    {
+        $model = EloquentUserModel::find($id);
+
+        if (null === $model) {
+            return null;
+        }
+
+        return $this->toDomain($model);
+    }
+
+    /**
      * Returns a paginated collection of persisted user entities.
      *
      * @param  int                                  $page    The page number to retrieve.
@@ -92,20 +109,19 @@ final class EloquentUserRepository implements UserRepositoryInterface
     }
 
     /**
-     * Returns a user by their unique identifier.
+     * Builds a domain User entity from an Eloquent model.
      *
-     * @param  int       $id The unique identifier of the user to retrieve.
-     * @return User|null The matching User entity, or null if not found.
+     * @param  EloquentUserModel $model The Eloquent model to convert.
+     * @return User              The corresponding domain entity.
      */
-    public function findById(int $id): ?User
+    private function toDomain(EloquentUserModel $model): User
     {
-        $model = EloquentUserModel::find($id);
-
-        if (null === $model) {
-            return null;
-        }
-
-        return $this->toDomain($model);
+        return new User(
+            id: $model->id,
+            firstName: $model->first_name,
+            lastName: $model->last_name,
+            email: $model->email
+        );
     }
 
     /**
@@ -140,21 +156,5 @@ final class EloquentUserRepository implements UserRepositoryInterface
         $model->save();
 
         return $this->toDomain($model);
-    }
-
-    /**
-     * Builds a domain User entity from an Eloquent model.
-     *
-     * @param  EloquentUserModel $model The Eloquent model to convert.
-     * @return User              The corresponding domain entity.
-     */
-    private function toDomain(EloquentUserModel $model): User
-    {
-        return new User(
-            id: $model->id,
-            firstName: $model->first_name,
-            lastName: $model->last_name,
-            email: $model->email
-        );
     }
 }

--- a/database/migrations/20161109121141_create_users_table.php
+++ b/database/migrations/20161109121141_create_users_table.php
@@ -10,6 +10,16 @@ use Phinx\Migration\AbstractMigration;
 final class CreateUsersTable extends AbstractMigration
 {
     /**
+     * Deletes the users table if it exists.
+     */
+    public function down(): void
+    {
+        if ($this->hasTable('users')) {
+            $this->table('users')->drop()->save();
+        }
+    }
+
+    /**
      * Creates the users table and its required columns.
      */
     public function up(): void
@@ -27,15 +37,5 @@ final class CreateUsersTable extends AbstractMigration
                 'update' => 'CURRENT_TIMESTAMP',
             ])
             ->create();
-    }
-
-    /**
-     * Deletes the users table if it exists.
-     */
-    public function down(): void
-    {
-        if ($this->hasTable('users')) {
-            $this->table('users')->drop()->save();
-        }
     }
 }

--- a/tests/Integration/AbstractTestCase.php
+++ b/tests/Integration/AbstractTestCase.php
@@ -30,12 +30,21 @@ abstract class AbstractTestCase extends TestCase
     protected Generator $faker;
 
     /**
-     * Builds the application state required before each test.
+     * Returns the decoded JSON response body.
+     *
+     * @param  ResponseInterface    $response The HTTP response.
+     * @return array<string, mixed> The decoded response data.
+     * @throws JsonException        If JSON decoding fails.
      */
-    protected function setUp(): void
+    protected function decodeJson(ResponseInterface $response): array
     {
-        $this->app = require_from_root('bootstrap/app.php')();
-        $this->faker = FakerFactory::create();
+        $body = (string)$response->getBody();
+
+        if ($body === '') {
+            return [];
+        }
+
+        return json_decode($body, true, 512, JSON_THROW_ON_ERROR);
     }
 
     /**
@@ -80,20 +89,11 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * Returns the decoded JSON response body.
-     *
-     * @param  ResponseInterface    $response The HTTP response.
-     * @return array<string, mixed> The decoded response data.
-     * @throws JsonException        If JSON decoding fails.
+     * Builds the application state required before each test.
      */
-    protected function decodeJson(ResponseInterface $response): array
+    protected function setUp(): void
     {
-        $body = (string)$response->getBody();
-
-        if ($body === '') {
-            return [];
-        }
-
-        return json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        $this->app = require_from_root('bootstrap/app.php')();
+        $this->faker = FakerFactory::create();
     }
 }

--- a/tests/Integration/Application/Actions/AbstractUserActionTestCase.php
+++ b/tests/Integration/Application/Actions/AbstractUserActionTestCase.php
@@ -16,14 +16,13 @@ use Tests\Support\Factories\UserFactory;
 abstract class AbstractUserActionTestCase extends AbstractTestCase
 {
     /**
-     * The user repository instance.
-     */
-    protected UserRepositoryInterface $userRepository;
-
-    /**
      * The user factory instance.
      */
     protected UserFactory $userFactory;
+    /**
+     * The user repository instance.
+     */
+    protected UserRepositoryInterface $userRepository;
 
     /**
      * Builds the user test dependencies before each test.

--- a/tests/Integration/Application/Actions/ListUserActionActionTest.php
+++ b/tests/Integration/Application/Actions/ListUserActionActionTest.php
@@ -12,18 +12,61 @@ use PHPUnit\Framework\Attributes\DataProvider;
 final class ListUserActionActionTest extends AbstractUserActionTestCase
 {
     /**
-     * Asserts that the total user count increases after new users are created.
+     * Provides invalid page query strings and their expected clamped values.
+     *
+     * @return array<string, array{string, int}>
      */
-    public function testTotalIncreasesAfterUsersAreCreated(): void
+    public static function invalidPageProvider(): array
     {
-        $beforeTotal = $this->decodeJson($this->request('GET', '/api/v1/users'))['meta']['total'];
+        return [
+            'zero page' => ['page=0&perPage=10', 1],
+            'negative page' => ['page=-5&perPage=10', 1],
+            'non-numeric' => ['page=abc&perPage=10', 1],
+        ];
+    }
 
-        $this->userFactory->create();
-        $this->userFactory->create();
+    /**
+     * Provides invalid perPage query strings and their expected clamped values.
+     *
+     * @return array<string, array{string, int}>
+     */
+    public static function invalidPerPageProvider(): array
+    {
+        return [
+            'zero perPage' => ['page=1&perPage=0', 1],
+            'negative perPage' => ['page=1&perPage=-10', 1],
+            'exceeds maximum' => ['page=1&perPage=999', 100],
+        ];
+    }
 
-        $afterTotal = $this->decodeJson($this->request('GET', '/api/v1/users'))['meta']['total'];
+    /**
+     * Asserts that an invalid page parameter is clamped to a valid value.
+     *
+     * @param string $query        The query string under test.
+     * @param int    $expectedPage The expected clamped page number.
+     */
+    #[DataProvider('invalidPageProvider')]
+    public function testInvalidPageIsClamped(string $query, int $expectedPage): void
+    {
+        $response = $this->request('GET', "/api/v1/users?{$query}");
 
-        $this->assertSame($beforeTotal + 2, $afterTotal);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($expectedPage, $this->decodeJson($response)['meta']['page']);
+    }
+
+    /**
+     * Asserts that an invalid perPage parameter is clamped to a valid value.
+     *
+     * @param string $query           The query string under test.
+     * @param int    $expectedPerPage The expected clamped page size.
+     */
+    #[DataProvider('invalidPerPageProvider')]
+    public function testInvalidPerPageIsClamped(string $query, int $expectedPerPage): void
+    {
+        $response = $this->request('GET', "/api/v1/users?{$query}");
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($expectedPerPage, $this->decodeJson($response)['meta']['perPage']);
     }
 
     /**
@@ -51,60 +94,17 @@ final class ListUserActionActionTest extends AbstractUserActionTestCase
     }
 
     /**
-     * Asserts that an invalid page parameter is clamped to a valid value.
-     *
-     * @param string $query        The query string under test.
-     * @param int    $expectedPage The expected clamped page number.
+     * Asserts that the total user count increases after new users are created.
      */
-    #[DataProvider('invalidPageProvider')]
-    public function testInvalidPageIsClamped(string $query, int $expectedPage): void
+    public function testTotalIncreasesAfterUsersAreCreated(): void
     {
-        $response = $this->request('GET', "/api/v1/users?{$query}");
+        $beforeTotal = $this->decodeJson($this->request('GET', '/api/v1/users'))['meta']['total'];
 
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame($expectedPage, $this->decodeJson($response)['meta']['page']);
-    }
+        $this->userFactory->create();
+        $this->userFactory->create();
 
-    /**
-     * Provides invalid page query strings and their expected clamped values.
-     *
-     * @return array<string, array{string, int}>
-     */
-    public static function invalidPageProvider(): array
-    {
-        return [
-            'zero page' => ['page=0&perPage=10', 1],
-            'negative page' => ['page=-5&perPage=10', 1],
-            'non-numeric' => ['page=abc&perPage=10', 1],
-        ];
-    }
+        $afterTotal = $this->decodeJson($this->request('GET', '/api/v1/users'))['meta']['total'];
 
-    /**
-     * Asserts that an invalid perPage parameter is clamped to a valid value.
-     *
-     * @param string $query           The query string under test.
-     * @param int    $expectedPerPage The expected clamped page size.
-     */
-    #[DataProvider('invalidPerPageProvider')]
-    public function testInvalidPerPageIsClamped(string $query, int $expectedPerPage): void
-    {
-        $response = $this->request('GET', "/api/v1/users?{$query}");
-
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame($expectedPerPage, $this->decodeJson($response)['meta']['perPage']);
-    }
-
-    /**
-     * Provides invalid perPage query strings and their expected clamped values.
-     *
-     * @return array<string, array{string, int}>
-     */
-    public static function invalidPerPageProvider(): array
-    {
-        return [
-            'zero perPage' => ['page=1&perPage=0', 1],
-            'negative perPage' => ['page=1&perPage=-10', 1],
-            'exceeds maximum' => ['page=1&perPage=999', 100],
-        ];
+        $this->assertSame($beforeTotal + 2, $afterTotal);
     }
 }

--- a/tests/Support/Persistence/Repositories/InMemoryUserRepository.php
+++ b/tests/Support/Persistence/Repositories/InMemoryUserRepository.php
@@ -82,6 +82,17 @@ final class InMemoryUserRepository implements UserRepositoryInterface
     }
 
     /**
+     * Returns a user by their ID from the in-memory store.
+     *
+     * @param  int       $id The unique identifier of the user to retrieve.
+     * @return User|null The matching User entity, or null if not found.
+     */
+    public function findById(int $id): ?User
+    {
+        return $this->store[$id] ?? null;
+    }
+
+    /**
      * Returns a paginated subset of users from the in-memory store.
      *
      * @param  int                              $page    The 1-indexed page number. Must be >= 1.
@@ -100,17 +111,6 @@ final class InMemoryUserRepository implements UserRepositoryInterface
             'users' => $users,
             'total' => $total,
         ];
-    }
-
-    /**
-     * Returns a user by their ID from the in-memory store.
-     *
-     * @param  int       $id The unique identifier of the user to retrieve.
-     * @return User|null The matching User entity, or null if not found.
-     */
-    public function findById(int $id): ?User
-    {
-        return $this->store[$id] ?? null;
     }
 
     /**

--- a/tests/Unit/Application/DTOs/Input/CreateUserInputTest.php
+++ b/tests/Unit/Application/DTOs/Input/CreateUserInputTest.php
@@ -14,6 +14,36 @@ use PHPUnit\Framework\TestCase;
 final class CreateUserInputTest extends TestCase
 {
     /**
+     * Provides input arrays with one or more missing required fields.
+     *
+     * @return array<string, array{array<string, string>}>
+     */
+    public static function invalidPayloadProvider(): array
+    {
+        return [
+            'missing first name' => [
+                [
+                    'last_name' => 'Doe',
+                    'email' => 'jane@example.com',
+                ],
+            ],
+            'missing last name' => [
+                [
+                    'first_name' => 'Jane',
+                    'email' => 'jane@example.com',
+                ],
+            ],
+            'missing email' => [
+                [
+                    'first_name' => 'Jane',
+                    'last_name' => 'Doe',
+                ],
+            ],
+            'empty payload' => [[]],
+        ];
+    }
+
+    /**
      * Asserts that an input object is successfully created when all required fields are present in the input array.
      */
     public function testCreatesInstanceWhenAllFieldsAreProvided(): void
@@ -43,35 +73,5 @@ final class CreateUserInputTest extends TestCase
         $this->expectExceptionMessage('Missing required fields');
 
         CreateUserInput::fromArray($payload);
-    }
-
-    /**
-     * Provides input arrays with one or more missing required fields.
-     *
-     * @return array<string, array{array<string, string>}>
-     */
-    public static function invalidPayloadProvider(): array
-    {
-        return [
-            'missing first name' => [
-                [
-                    'last_name' => 'Doe',
-                    'email' => 'jane@example.com',
-                ],
-            ],
-            'missing last name' => [
-                [
-                    'first_name' => 'Jane',
-                    'email' => 'jane@example.com',
-                ],
-            ],
-            'missing email' => [
-                [
-                    'first_name' => 'Jane',
-                    'last_name' => 'Doe',
-                ],
-            ],
-            'empty payload' => [[]],
-        ];
     }
 }

--- a/tests/Unit/Application/DTOs/Input/UpdateUserInputTest.php
+++ b/tests/Unit/Application/DTOs/Input/UpdateUserInputTest.php
@@ -13,6 +13,19 @@ use PHPUnit\Framework\TestCase;
 final class UpdateUserInputTest extends TestCase
 {
     /**
+     * Asserts that absent fields are set to null, allowing only the provided fields to be updated.
+     */
+    public function testAllowsPartialUpdateWhenSomeFieldsAreOmitted(): void
+    {
+        $input = UpdateUserInput::fromArray(7, ['first_name' => 'Janet']);
+
+        $this->assertSame(7, $input->id);
+        $this->assertSame('Janet', $input->firstName);
+        $this->assertNull($input->lastName);
+        $this->assertNull($input->email);
+    }
+
+    /**
      * Asserts that all fields are correctly mapped when a complete input array is provided.
      */
     public function testCreatesInstanceWhenAllFieldsAreProvided(): void
@@ -29,19 +42,6 @@ final class UpdateUserInputTest extends TestCase
         $this->assertSame('Jane', $input->firstName);
         $this->assertSame('Doe', $input->lastName);
         $this->assertSame('jane@example.com', $input->email);
-    }
-
-    /**
-     * Asserts that absent fields are set to null, allowing only the provided fields to be updated.
-     */
-    public function testAllowsPartialUpdateWhenSomeFieldsAreOmitted(): void
-    {
-        $input = UpdateUserInput::fromArray(7, ['first_name' => 'Janet']);
-
-        $this->assertSame(7, $input->id);
-        $this->assertSame('Janet', $input->firstName);
-        $this->assertNull($input->lastName);
-        $this->assertNull($input->email);
     }
 
     /**

--- a/tests/Unit/Application/Services/UserServiceTest.php
+++ b/tests/Unit/Application/Services/UserServiceTest.php
@@ -32,83 +32,6 @@ final class UserServiceTest extends TestCase
     }
 
     /**
-     * Asserts that all seeded users are returned and the first entry has the expected data.
-     */
-    public function testReturnsAllUsersWhenUsersExist(): void
-    {
-        $users = $this->userService->all();
-
-        $this->assertIsArray($users);
-        $this->assertCount(5, $users);
-        $this->assertSame('Oliver', $users[0]->getFirstName());
-        $this->assertSame('French', $users[0]->getLastName());
-    }
-
-    /**
-     * Asserts that paginated results contain the correct number of users.
-     */
-    public function testReturnsPaginatedUsersWithCorrectCount(): void
-    {
-        $result = $this->userService->paginated(1, 2);
-
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('users', $result);
-        $this->assertArrayHasKey('total', $result);
-        $this->assertCount(2, $result['users']);
-        $this->assertSame(5, $result['total']);
-    }
-
-    /**
-     * Asserts that the second page of paginated results contains different users.
-     */
-    public function testReturnsCorrectUsersForSecondPage(): void
-    {
-        $firstPageResult = $this->userService->paginated(1, 2);
-        $secondPageResult = $this->userService->paginated(2, 2);
-
-        $this->assertCount(2, $secondPageResult['users']);
-        $this->assertNotSame(
-            $firstPageResult['users'][0]->getId(),
-            $secondPageResult['users'][0]->getId()
-        );
-    }
-
-    /**
-     * Asserts that paginated results respect the perPage parameter.
-     */
-    public function testRespectsPerPageParameter(): void
-    {
-        $result = $this->userService->paginated(1, 3);
-
-        $this->assertCount(3, $result['users']);
-        $this->assertSame(5, $result['total']);
-    }
-
-    /**
-     * Asserts that an empty array is returned when requesting a page beyond available data.
-     */
-    public function testReturnsEmptyArrayWhenPageExceedsTotalPages(): void
-    {
-        $result = $this->userService->paginated(10, 10);
-
-        $this->assertEmpty($result['users']);
-        $this->assertSame(5, $result['total']);
-    }
-
-    /**
-     * Asserts that the final page returns the remaining partial set of users.
-     */
-    public function testReturnsPartialFinalPage(): void
-    {
-        $result = $this->userService->paginated(2, 3);
-
-        $this->assertCount(2, $result['users']);
-        $this->assertSame(5, $result['total']);
-        $this->assertSame(4, $result['users'][0]->getId());
-        $this->assertSame(5, $result['users'][1]->getId());
-    }
-
-    /**
      * Asserts that a User entity with the correct data is returned after a successful creation.
      */
     public function testCreatesUserWhenValidDataIsProvided(): void
@@ -128,6 +51,146 @@ final class UserServiceTest extends TestCase
     }
 
     /**
+     * Asserts that the total user count decreases by one after a successful deletion.
+     */
+    public function testDecreasesUserCountWhenUserIsDeleted(): void
+    {
+        $initialCount = count($this->userService->all());
+
+        $this->userService->delete(1);
+
+        $finalCount = count($this->userService->all());
+
+        $this->assertSame($initialCount - 1, $finalCount);
+    }
+
+    /**
+     * Asserts that the user can no longer be found after a successful deletion.
+     */
+    public function testDeletesUserWhenUserExists(): void
+    {
+        $this->userService->delete(3);
+
+        $this->expectException(UserNotFoundException::class);
+        $this->userService->find(3);
+    }
+
+    /**
+     * Asserts that the total user count increases by one after a successful creation.
+     */
+    public function testIncreasesUserCountWhenUserIsCreated(): void
+    {
+        $initialCount = count($this->userService->all());
+
+        $input = new CreateUserInput(
+            firstName: 'New',
+            lastName: 'User',
+            email: 'new@example.com'
+        );
+
+        $this->userService->create($input);
+
+        $finalCount = count($this->userService->all());
+
+        $this->assertSame($initialCount + 1, $finalCount);
+    }
+
+    /**
+     * Asserts that fields omitted from the update input retain their original values.
+     */
+    public function testPreservesUnchangedFieldsWhenPartialDataIsProvided(): void
+    {
+        $input = new UpdateUserInput(
+            id: 2,
+            firstName: 'Stephen'
+        );
+
+        $user = $this->userService->update($input);
+
+        $this->assertSame(2, $user->getId());
+        $this->assertSame('Stephen', $user->getFirstName());
+        $this->assertSame('Anderson', $user->getLastName());
+        $this->assertSame('charlotte.anderson@example.com', $user->getEmail());
+    }
+
+    /**
+     * Asserts that paginated results respect the perPage parameter.
+     */
+    public function testRespectsPerPageParameter(): void
+    {
+        $result = $this->userService->paginated(1, 3);
+
+        $this->assertCount(3, $result['users']);
+        $this->assertSame(5, $result['total']);
+    }
+
+    /**
+     * Asserts that all seeded users are returned and the first entry has the expected data.
+     */
+    public function testReturnsAllUsersWhenUsersExist(): void
+    {
+        $users = $this->userService->all();
+
+        $this->assertIsArray($users);
+        $this->assertCount(5, $users);
+        $this->assertSame('Oliver', $users[0]->getFirstName());
+        $this->assertSame('French', $users[0]->getLastName());
+    }
+
+    /**
+     * Asserts that the second page of paginated results contains different users.
+     */
+    public function testReturnsCorrectUsersForSecondPage(): void
+    {
+        $firstPageResult = $this->userService->paginated(1, 2);
+        $secondPageResult = $this->userService->paginated(2, 2);
+
+        $this->assertCount(2, $secondPageResult['users']);
+        $this->assertNotSame(
+            $firstPageResult['users'][0]->getId(),
+            $secondPageResult['users'][0]->getId()
+        );
+    }
+
+    /**
+     * Asserts that an empty array is returned when requesting a page beyond available data.
+     */
+    public function testReturnsEmptyArrayWhenPageExceedsTotalPages(): void
+    {
+        $result = $this->userService->paginated(10, 10);
+
+        $this->assertEmpty($result['users']);
+        $this->assertSame(5, $result['total']);
+    }
+
+    /**
+     * Asserts that paginated results contain the correct number of users.
+     */
+    public function testReturnsPaginatedUsersWithCorrectCount(): void
+    {
+        $result = $this->userService->paginated(1, 2);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('users', $result);
+        $this->assertArrayHasKey('total', $result);
+        $this->assertCount(2, $result['users']);
+        $this->assertSame(5, $result['total']);
+    }
+
+    /**
+     * Asserts that the final page returns the remaining partial set of users.
+     */
+    public function testReturnsPartialFinalPage(): void
+    {
+        $result = $this->userService->paginated(2, 3);
+
+        $this->assertCount(2, $result['users']);
+        $this->assertSame(5, $result['total']);
+        $this->assertSame(4, $result['users'][0]->getId());
+        $this->assertSame(5, $result['users'][1]->getId());
+    }
+
+    /**
      * Asserts that the correct User entity is returned when searching by an existing ID.
      */
     public function testReturnsUserWhenUserExists(): void
@@ -138,6 +201,33 @@ final class UserServiceTest extends TestCase
         $this->assertSame('Oliver', $user->getFirstName());
         $this->assertSame('French', $user->getLastName());
         $this->assertSame('oliver.french@example.com', $user->getEmail());
+    }
+
+    /**
+     * Asserts that UserNotFoundException is thrown when deleting a non-existent user.
+     */
+    public function testThrowsUserNotFoundExceptionWhenDeletingNonExistentUser(): void
+    {
+        $this->expectException(UserNotFoundException::class);
+        $this->expectExceptionMessage('User with ID 999 not found.');
+
+        $this->userService->delete(999);
+    }
+
+    /**
+     * Asserts that UserNotFoundException is thrown when attempting to update a non-existent user.
+     */
+    public function testThrowsUserNotFoundExceptionWhenUpdatingNonExistentUser(): void
+    {
+        $input = new UpdateUserInput(
+            id: 999,
+            firstName: 'Test'
+        );
+
+        $this->expectException(UserNotFoundException::class);
+        $this->expectExceptionMessage('User with ID 999 not found.');
+
+        $this->userService->update($input);
     }
 
     /**
@@ -169,95 +259,5 @@ final class UserServiceTest extends TestCase
         $this->assertSame('William', $user->getFirstName());
         $this->assertSame('French III', $user->getLastName());
         $this->assertSame('william.gates@example.com', $user->getEmail());
-    }
-
-    /**
-     * Asserts that fields omitted from the update input retain their original values.
-     */
-    public function testPreservesUnchangedFieldsWhenPartialDataIsProvided(): void
-    {
-        $input = new UpdateUserInput(
-            id: 2,
-            firstName: 'Stephen'
-        );
-
-        $user = $this->userService->update($input);
-
-        $this->assertSame(2, $user->getId());
-        $this->assertSame('Stephen', $user->getFirstName());
-        $this->assertSame('Anderson', $user->getLastName());
-        $this->assertSame('charlotte.anderson@example.com', $user->getEmail());
-    }
-
-    /**
-     * Asserts that UserNotFoundException is thrown when attempting to update a non-existent user.
-     */
-    public function testThrowsUserNotFoundExceptionWhenUpdatingNonExistentUser(): void
-    {
-        $input = new UpdateUserInput(
-            id: 999,
-            firstName: 'Test'
-        );
-
-        $this->expectException(UserNotFoundException::class);
-        $this->expectExceptionMessage('User with ID 999 not found.');
-
-        $this->userService->update($input);
-    }
-
-    /**
-     * Asserts that the user can no longer be found after a successful deletion.
-     */
-    public function testDeletesUserWhenUserExists(): void
-    {
-        $this->userService->delete(3);
-
-        $this->expectException(UserNotFoundException::class);
-        $this->userService->find(3);
-    }
-
-    /**
-     * Asserts that UserNotFoundException is thrown when deleting a non-existent user.
-     */
-    public function testThrowsUserNotFoundExceptionWhenDeletingNonExistentUser(): void
-    {
-        $this->expectException(UserNotFoundException::class);
-        $this->expectExceptionMessage('User with ID 999 not found.');
-
-        $this->userService->delete(999);
-    }
-
-    /**
-     * Asserts that the total user count increases by one after a successful creation.
-     */
-    public function testIncreasesUserCountWhenUserIsCreated(): void
-    {
-        $initialCount = count($this->userService->all());
-
-        $input = new CreateUserInput(
-            firstName: 'New',
-            lastName: 'User',
-            email: 'new@example.com'
-        );
-
-        $this->userService->create($input);
-
-        $finalCount = count($this->userService->all());
-
-        $this->assertSame($initialCount + 1, $finalCount);
-    }
-
-    /**
-     * Asserts that the total user count decreases by one after a successful deletion.
-     */
-    public function testDecreasesUserCountWhenUserIsDeleted(): void
-    {
-        $initialCount = count($this->userService->all());
-
-        $this->userService->delete(1);
-
-        $finalCount = count($this->userService->all());
-
-        $this->assertSame($initialCount - 1, $finalCount);
     }
 }

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -13,29 +13,9 @@ use PHPUnit\Framework\TestCase;
 final class HelpersTest extends TestCase
 {
     /**
-     * Environment variable keys used by these tests.
-     *
-     * @var list<string>
-     */
-    private const ENVIRONMENT_KEYS = [
-        'SOME_KEY',
-        'FLAG_KEY',
-        'LIST_KEY',
-        'MISSING_KEY',
-        'PROCESS_ENV_KEY',
-        'SERVER_ENV_KEY',
-        'PRECEDENCE_KEY',
-    ];
-
-    /**
      * Backup of the original environment variables array.
      */
     private array $originalEnv;
-
-    /**
-     * Backup of the original server variables array.
-     */
-    private array $originalServer;
 
     /**
      * Backup of the original process environment values used by these tests.
@@ -43,6 +23,28 @@ final class HelpersTest extends TestCase
      * @var array<string, string|false>
      */
     private array $originalProcessEnvironment;
+
+    /**
+     * Backup of the original server variables array.
+     */
+    private array $originalServer;
+
+    /**
+     * Provides boolean strings with representative casing.
+     *
+     * @return array<string, array{string, bool}>
+     */
+    public static function booleanValueProvider(): array
+    {
+        return [
+            'true lowercase' => ['true', true],
+            'false lowercase' => ['false', false],
+            'true uppercase' => ['TRUE', true],
+            'false uppercase' => ['FALSE', false],
+            'true mixed case' => ['True', true],
+            'false mixed case' => ['False', false],
+        ];
+    }
 
     /**
      * Builds backups of environment variables before each test.
@@ -85,41 +87,55 @@ final class HelpersTest extends TestCase
     }
 
     /**
-     * Asserts that the default value is returned when the key is missing.
+     * Asserts that an empty array is returned when the key is missing.
      */
-    public function testGetEnvReturnsDefaultWhenMissing(): void
+    public function testGetEnvArrayReturnsEmptyWhenMissing(): void
     {
-        $this->assertSame('default', get_env('MISSING_KEY', 'default'));
+        $this->assertSame([], get_env_array('LIST_KEY'));
     }
 
     /**
-     * Asserts that string values are returned without modification.
+     * Asserts that comma-separated values are split into an array.
      */
-    public function testGetEnvReturnsStringValue(): void
+    public function testGetEnvArraySplitsValues(): void
     {
-        $_ENV['SOME_KEY'] = 'some-value';
+        $_ENV['LIST_KEY'] = 'a,b,c';
 
-        $this->assertSame('some-value', get_env('SOME_KEY'));
+        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY'));
     }
 
     /**
-     * Asserts that server environment variables are available when $_ENV is not populated.
+     * Asserts that values are trimmed and empty entries are removed.
      */
-    public function testGetEnvReturnsServerEnvironmentValue(): void
+    public function testGetEnvArrayTrimsAndFilters(): void
     {
-        $_SERVER['SERVER_ENV_KEY'] = 'server-value';
+        $_ENV['LIST_KEY'] = ' a, ,b , , c ';
 
-        $this->assertSame('server-value', get_env('SERVER_ENV_KEY'));
+        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY'));
     }
 
     /**
-     * Asserts that process environment variables are available when $_ENV is not populated.
+     * Asserts that values can be split using a custom delimiter.
      */
-    public function testGetEnvReturnsProcessEnvironmentValue(): void
+    public function testGetEnvArrayUsesCustomDelimiter(): void
     {
-        putenv('PROCESS_ENV_KEY=process-value');
+        $_ENV['LIST_KEY'] = 'a|b|c';
 
-        $this->assertSame('process-value', get_env('PROCESS_ENV_KEY'));
+        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY', '|'));
+    }
+
+    /**
+     * Asserts that boolean strings are cast without regard to case.
+     *
+     * @param string $value    The environment variable value to cast.
+     * @param bool   $expected The expected cast value.
+     */
+    #[DataProvider('booleanValueProvider')]
+    public function testGetEnvCastsBooleanStrings(string $value, bool $expected): void
+    {
+        $_ENV['FLAG_KEY'] = $value;
+
+        $this->assertSame($expected, get_env('FLAG_KEY'));
     }
 
     /**
@@ -156,71 +172,54 @@ final class HelpersTest extends TestCase
     }
 
     /**
-     * Asserts that boolean strings are cast without regard to case.
+     * Asserts that the default value is returned when the key is missing.
+     */
+    public function testGetEnvReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame('default', get_env('MISSING_KEY', 'default'));
+    }
+
+    /**
+     * Asserts that process environment variables are available when $_ENV is not populated.
+     */
+    public function testGetEnvReturnsProcessEnvironmentValue(): void
+    {
+        putenv('PROCESS_ENV_KEY=process-value');
+
+        $this->assertSame('process-value', get_env('PROCESS_ENV_KEY'));
+    }
+
+    /**
+     * Asserts that server environment variables are available when $_ENV is not populated.
+     */
+    public function testGetEnvReturnsServerEnvironmentValue(): void
+    {
+        $_SERVER['SERVER_ENV_KEY'] = 'server-value';
+
+        $this->assertSame('server-value', get_env('SERVER_ENV_KEY'));
+    }
+
+    /**
+     * Asserts that string values are returned without modification.
+     */
+    public function testGetEnvReturnsStringValue(): void
+    {
+        $_ENV['SOME_KEY'] = 'some-value';
+
+        $this->assertSame('some-value', get_env('SOME_KEY'));
+    }
+    /**
+     * Environment variable keys used by these tests.
      *
-     * @param string $value    The environment variable value to cast.
-     * @param bool   $expected The expected cast value.
+     * @var list<string>
      */
-    #[DataProvider('booleanValueProvider')]
-    public function testGetEnvCastsBooleanStrings(string $value, bool $expected): void
-    {
-        $_ENV['FLAG_KEY'] = $value;
-
-        $this->assertSame($expected, get_env('FLAG_KEY'));
-    }
-
-    /**
-     * Provides boolean strings with representative casing.
-     *
-     * @return array<string, array{string, bool}>
-     */
-    public static function booleanValueProvider(): array
-    {
-        return [
-            'true lowercase' => ['true', true],
-            'false lowercase' => ['false', false],
-            'true uppercase' => ['TRUE', true],
-            'false uppercase' => ['FALSE', false],
-            'true mixed case' => ['True', true],
-            'false mixed case' => ['False', false],
-        ];
-    }
-
-    /**
-     * Asserts that an empty array is returned when the key is missing.
-     */
-    public function testGetEnvArrayReturnsEmptyWhenMissing(): void
-    {
-        $this->assertSame([], get_env_array('LIST_KEY'));
-    }
-
-    /**
-     * Asserts that comma-separated values are split into an array.
-     */
-    public function testGetEnvArraySplitsValues(): void
-    {
-        $_ENV['LIST_KEY'] = 'a,b,c';
-
-        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY'));
-    }
-
-    /**
-     * Asserts that values can be split using a custom delimiter.
-     */
-    public function testGetEnvArrayUsesCustomDelimiter(): void
-    {
-        $_ENV['LIST_KEY'] = 'a|b|c';
-
-        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY', '|'));
-    }
-
-    /**
-     * Asserts that values are trimmed and empty entries are removed.
-     */
-    public function testGetEnvArrayTrimsAndFilters(): void
-    {
-        $_ENV['LIST_KEY'] = ' a, ,b , , c ';
-
-        $this->assertSame(['a', 'b', 'c'], get_env_array('LIST_KEY'));
-    }
+    private const ENVIRONMENT_KEYS = [
+        'SOME_KEY',
+        'FLAG_KEY',
+        'LIST_KEY',
+        'MISSING_KEY',
+        'PROCESS_ENV_KEY',
+        'SERVER_ENV_KEY',
+        'PRECEDENCE_KEY',
+    ];
 }


### PR DESCRIPTION
## Description

This pull request introduces several improvements and refactorings to the user repository, persistence layer, and test suite. The main focus is on cleaning up code duplication, improving maintainability, and enhancing test clarity. Notably, the `findById` method is refactored and consistently implemented across repository interfaces and test doubles, domain model mapping is centralized, and test provider methods are reorganized for better readability.

## Proposed Changes

**Repository and Persistence Layer Refactoring:**

* The `findById` method is now consistently declared in `UserRepositoryInterface` and implemented in both `EloquentUserRepository` and `InMemoryUserRepository`, ensuring alignment across production and test code. [[1]](diffhunk://#diff-20719d9b0da30e142fd6fb266ba3e0dc3dbe3529784197e807e0a851d300dd66R39-R46) [[2]](diffhunk://#diff-20719d9b0da30e142fd6fb266ba3e0dc3dbe3529784197e807e0a851d300dd66L48-L55) [[3]](diffhunk://#diff-7ccd4037aea4c27a90e3419add3187366a347171414f1f387b2e82b576dc6b8bR66-R82) [[4]](diffhunk://#diff-7ccd4037aea4c27a90e3419add3187366a347171414f1f387b2e82b576dc6b8bL95-R124) [[5]](diffhunk://#diff-1b54f42eec3c6122dcc622c2c104e08d550d741f1f5cbd934cc1ab914a43042dR84-R94) [[6]](diffhunk://#diff-1b54f42eec3c6122dcc622c2c104e08d550d741f1f5cbd934cc1ab914a43042dL105-L115)
* The `toDomain` method in `EloquentUserRepository` is now private and only defined once, reducing duplication and clarifying its usage. [[1]](diffhunk://#diff-7ccd4037aea4c27a90e3419add3187366a347171414f1f387b2e82b576dc6b8bL95-R124) [[2]](diffhunk://#diff-7ccd4037aea4c27a90e3419add3187366a347171414f1f387b2e82b576dc6b8bL144-L159)
* The `$table` property in `EloquentUserModel` is moved for better grouping with other model properties. [[1]](diffhunk://#diff-c2971b6f18c21ca1ca45a17c4e3d0fd2a821f55d717004c81697aadc04e17c1aL16-L22) [[2]](diffhunk://#diff-c2971b6f18c21ca1ca45a17c4e3d0fd2a821f55d717004c81697aadc04e17c1aR26-R31)

**Testing Improvements:**

* Data provider methods and test logic in `ListUserActionActionTest` and `CreateUserInputTest` are reorganized for clarity, with providers moved closer to their usage and some test order improved for readability. [[1]](diffhunk://#diff-583e8bf0dac78b0292874715cd062c03d7b22463c3bf517a7379e750746efebcL15-R39) [[2]](diffhunk://#diff-583e8bf0dac78b0292874715cd062c03d7b22463c3bf517a7379e750746efebcL68-L81) [[3]](diffhunk://#diff-583e8bf0dac78b0292874715cd062c03d7b22463c3bf517a7379e750746efebcL98-R108) [[4]](diffhunk://#diff-7e89545e0c89bc4fedb8f1e85e5540f068485daa433be6b2055c4fd48d0870b2R16-R45) [[5]](diffhunk://#diff-7e89545e0c89bc4fedb8f1e85e5540f068485daa433be6b2055c4fd48d0870b2L47-L76)
* A new test is added to `UpdateUserInputTest` to assert that partial updates correctly set omitted fields to `null`. [[1]](diffhunk://#diff-75a3b667b5de06040e78033077b7f89a7f1375f837ef2a6c9da10d52b0143d74R15-R27) [[2]](diffhunk://#diff-75a3b667b5de06040e78033077b7f89a7f1375f837ef2a6c9da10d52b0143d74L34-L46)
* The order of properties in `AbstractUserActionTestCase` is adjusted for consistency.
* The `decodeJson` and `setUp` methods in `AbstractTestCase` are reordered to better reflect their usage. [[1]](diffhunk://#diff-1be29371e8fd255c479aae65384e59ff30310b23285c230c279ef54eca5acb57L33-R47) [[2]](diffhunk://#diff-1be29371e8fd255c479aae65384e59ff30310b23285c230c279ef54eca5acb57L83-R97)

**Other Improvements:**

* A new `.php-cs-fixer` rule is added to enforce ordering of class elements by property then method, sorted alphabetically, improving code style consistency.
* The `down` migration for the users table is repositioned for clarity in the migration file. [[1]](diffhunk://#diff-367741f0bae10d390f52fee84eb2a39f15bd9b8ff982f074bc5a557015d38810R12-R21) [[2]](diffhunk://#diff-367741f0bae10d390f52fee84eb2a39f15bd9b8ff982f074bc5a557015d38810L31-L40)

## Type of Change

- [ ] `feat` — new feature (minor version bump)
- [ ] `fix` — bug fix (patch version bump)
- [ ] `deps` — dependency update (patch version bump when releasable)
- [x] `chore` / `docs` / `refactor` / `test` / `ci` / `build` — no version bump
- [ ] `feat!` or `BREAKING CHANGE:` — breaking change (major version bump)

## Related Issue

N/A

## Checklist

- [x] PR title follows Conventional Commits format: `<type>[optional scope]: <description>`
- [x] Description is a single paragraph suitable for the squash-merge commit body
- [x] PHP code has been formatted with `composer cs` (when applicable)
- [x] Tests have been added or updated where appropriate
- [x] All tests pass with `composer test`
- [ ] Dependency changes are reflected in `composer.json` and `composer.lock` where appropriate
- [ ] Breaking changes in updated dependencies have been assessed (dependency changes only)
- [ ] Fix has been verified locally (bug fixes only)
